### PR TITLE
ci: run lint with the previous deno version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
 
       - name: Setup
         uses: denoland/setup-deno@v2
+        with:
+          # https://github.com/denoland/deno/issues/28201
+          deno-version: v2.1.10
 
       - name: Test
         run: deno task lint

--- a/deno.json
+++ b/deno.json
@@ -15,11 +15,11 @@
     "bump": "gh workflow run bump",
     "compile": "deno run -A tool/forge/compile.ts",
     "install": "deno task compile --install=$HOME/.local/bin",
-    "test": "deno test -A --unstable-kv --doc **/*.ts",
+    "test": "deno test --no-check -A --unstable-kv --doc **/*.ts",
     "coverage": "deno task test --coverage && deno coverage --html",
-    "lint": "deno fmt -q --check && deno lint -q && deno check -q **/*.ts",
+    "lint": "deno fmt -q --check && deno lint -q && deno check -rq **/*.ts",
     "doc": "deno doc --lint --html $(find . -path '**/*.ts' -type file)",
-    "ok": "deno task lint && deno task doc && deno task test && deno publish --quiet --dry-run --allow-dirty"
+    "ok": "deno task lint && deno task doc && deno task test && deno publish -q --dry-run --allow-dirty"
   },
   "compilerOptions": {
     "exactOptionalPropertyTypes": true,


### PR DESCRIPTION
Works around bug in deno type checker.