### PR TITLE
fix(git): remove `Git.directory`

### DIFF
--- a/core/git/git.test.ts
+++ b/core/git/git.test.ts
@@ -39,8 +39,8 @@ Deno.test("git().clone() clones a repo", async () => {
   await remote.commit("second", { allowEmpty: true });
   await using directory = await tempDirectory();
   const repo = git({ cwd: directory.path() });
-  await repo.clone(remote.directory);
-  assertEquals(await repo.remote(), remote.directory);
+  await repo.clone(remote.path());
+  assertEquals(await repo.remote(), remote.path());
   assertEquals(await repo.log(), await remote.log());
 });
 
@@ -49,8 +49,8 @@ Deno.test("git().clone() clones a repo with remote name", async () => {
   await remote.commit("commit", { allowEmpty: true });
   await using directory = await tempDirectory();
   const repo = git({ cwd: directory.path() });
-  await repo.clone(remote.directory, { remote: "remote" });
-  assertEquals(await repo.remote({ remote: "remote" }), remote.directory);
+  await repo.clone(remote.path(), { remote: "remote" });
+  assertEquals(await repo.remote({ remote: "remote" }), remote.path());
   assertEquals(await repo.log(), await remote.log());
 });
 
@@ -61,7 +61,7 @@ Deno.test("git().clone() checks out a branch", async () => {
   await remote.checkout({ target, newBranch: "branch" });
   await using directory = await tempDirectory();
   const repo = git({ cwd: directory.path() });
-  await repo.clone(remote.directory, { branch: "branch" });
+  await repo.clone(remote.path(), { branch: "branch" });
   assertEquals(await repo.log(), [target]);
 });
 
@@ -72,7 +72,7 @@ Deno.test("git().clone() can do a shallow copy", async () => {
   const third = await remote.commit("third", { allowEmpty: true });
   await using directory = await tempDirectory();
   const repo = git({ cwd: directory.path() });
-  await repo.clone(remote.directory, { depth: 1, local: false });
+  await repo.clone(remote.path(), { depth: 1, local: false });
   assertEquals(await repo.log(), [third]);
 });
 
@@ -81,7 +81,7 @@ Deno.test("git().clone() local is no-op for local remote", async () => {
   const commit = await remote.commit("commit", { allowEmpty: true });
   await using directory = await tempDirectory();
   const repo = git({ cwd: directory.path() });
-  await repo.clone(remote.directory, { local: true });
+  await repo.clone(remote.path(), { local: true });
   assertEquals(await repo.log(), [commit]);
 });
 
@@ -94,7 +94,7 @@ Deno.test("git().clone() can do a shallow copy of multiple branches", async () =
   const third = await remote.commit("third", { allowEmpty: true });
   await using directory = await tempDirectory();
   const repo = git({ cwd: directory.path() });
-  await repo.clone(remote.directory, {
+  await repo.clone(remote.path(), {
     branch: "branch1",
     depth: 1,
     local: false,
@@ -114,7 +114,7 @@ Deno.test("git().clone() can copy a single branch", async () => {
   await remote.commit("third", { allowEmpty: true });
   await using directory = await tempDirectory();
   const repo = git({ cwd: directory.path() });
-  await repo.clone(remote.directory, { branch: "branch1", singleBranch: true });
+  await repo.clone(remote.path(), { branch: "branch1", singleBranch: true });
   assertEquals(await repo.log(), [second, first]);
   await assertRejects(() => repo.checkout({ target: "branch2" }), GitError);
 });
@@ -680,7 +680,7 @@ Deno.test("git().remoteDefaultBranch() can use remote name", async () => {
   await remote.commit("commit", { allowEmpty: true });
   const branch = await remote.branch();
   await using repo = await tempRepo();
-  await repo.addRemote(remote.directory, { remote: "remote" });
+  await repo.addRemote(remote.path(), { remote: "remote" });
   assertEquals(await repo.remoteDefaultBranch({ remote: "remote" }), branch);
 });
 
@@ -715,7 +715,7 @@ Deno.test("git().push() pushes commits to remote with name", async () => {
   const branch = await remote.branch();
   assert(branch);
   await using repo = await tempRepo();
-  await repo.addRemote(remote.directory, { remote: "remote" });
+  await repo.addRemote(remote.path(), { remote: "remote" });
   const commit = await repo.commit("commit", { allowEmpty: true });
   await repo.push({ remote: "remote", branch });
   assertEquals(await remote.log(), [commit]);
@@ -800,7 +800,7 @@ Deno.test("git().pull() can pull from remote with name", async () => {
   const branch = await remote.branch();
   assert(branch);
   await using repo = await tempRepo();
-  await repo.addRemote(remote.directory, { remote: "remote" });
+  await repo.addRemote(remote.path(), { remote: "remote" });
   await repo.pull({ remote: "remote", branch });
   assertEquals(await repo.log(), [commit]);
 });

--- a/core/git/git.ts
+++ b/core/git/git.ts
@@ -72,9 +72,7 @@ export class GitError extends Error {
 
 /** A local repository returned by {@linkcode git}. */
 export interface Git {
-  /** Local repository directory. */
-  directory: string;
-  /** Returns the full path to a file in the repository. */
+  /** Returns the repository directory, with optional relative children. */
   path: (...parts: string[]) => string;
   /** Configures repository options. */
   config: (config: Config) => Promise<void>;
@@ -435,11 +433,11 @@ export interface PullOptions
  * ```
  */
 export function git(options?: GitOptions): Git {
+  const directory = options?.cwd ?? ".";
   const gitOptions = options ?? {};
   return {
-    directory: options?.cwd ?? ".",
     path(...parts: string[]) {
-      return join(this.directory, ...parts);
+      return join(directory, ...parts);
     },
     async init(options) {
       await run(

--- a/core/git/testing.test.ts
+++ b/core/git/testing.test.ts
@@ -1,6 +1,6 @@
+import { tempRepo, testCommit } from "@roka/git/testing";
 import { assert } from "@std/assert/assert";
 import { assertEquals } from "@std/assert/equals";
-import { testCommit } from "./testing.ts";
 
 Deno.test("testCommit() creates a commit with fake data", () => {
   const commit = testCommit();
@@ -18,4 +18,26 @@ Deno.test("testCommit() can override fields", () => {
   const commit = testCommit({ summary: "test-summary", body: "test-body" });
   assertEquals(commit.summary, "test-summary");
   assertEquals(commit.body, "test-body");
+});
+
+Deno.test("tempRepo() creates a repo", async () => {
+  await using repo = await tempRepo();
+  const commit = await repo.commit("initial", { allowEmpty: true });
+  assertEquals(await repo.head(), commit);
+});
+
+Deno.test("tempRepo() can clone a repo from another repo", async () => {
+  await using remote = await tempRepo({ bare: true });
+  await using repo = await tempRepo({ clone: remote });
+  const commit = await repo.commit("initial", { allowEmpty: true });
+  await repo.push();
+  assertEquals(await remote.head(), commit);
+});
+
+Deno.test("tempRepo() can clone a repo from path", async () => {
+  await using remote = await tempRepo({ bare: true });
+  await using repo = await tempRepo({ clone: remote.path() });
+  const commit = await repo.commit("initial", { allowEmpty: true });
+  await repo.push();
+  assertEquals(await remote.head(), commit);
 });

--- a/core/git/testing.ts
+++ b/core/git/testing.ts
@@ -50,7 +50,7 @@ export function testCommit(commit?: Partial<Commit>): Commit {
 /** Options for {@linkcode tempRepo}. */
 export interface TempRepoOptions {
   /** Clone given repo, instead of creating an emtpy one. */
-  clone?: Git;
+  clone?: string | Git;
   /** Create a bare repository. */
   bare?: boolean;
 }
@@ -84,7 +84,8 @@ export async function tempRepo(
   };
   const repo = git({ cwd });
   if (clone) {
-    await git({ cwd }).clone(clone.directory, { bare, config });
+    const target = typeof clone === "string" ? clone : clone.path();
+    await git({ cwd }).clone(target, { bare, config });
   } else {
     await repo.init({ bare });
     await repo.config(config);

--- a/core/package/package.test.ts
+++ b/core/package/package.test.ts
@@ -24,7 +24,7 @@ async function createPackage(
 
 Deno.test("getPackage() fails on non-Deno package", async () => {
   await using repo = await tempRepo();
-  await assertRejects(() => getPackage({ directory: repo.directory }));
+  await assertRejects(() => getPackage({ directory: repo.path() }));
 });
 
 Deno.test("getPackage() returns current package", async () => {
@@ -51,9 +51,9 @@ Deno.test("getPackage() returns release version at release commit", async () => 
   await createPackage(repo.path(), { name: "@scope/module", version: "1.2.4" });
   await repo.commit("initial", { allowEmpty: true });
   const tag = await repo.tag("module@1.2.4");
-  const pkg = await getPackage({ directory: repo.directory });
+  const pkg = await getPackage({ directory: repo.path() });
   assertEquals(pkg, {
-    directory: repo.directory,
+    directory: repo.path(),
     module: "module",
     version: "1.2.4",
     config: { name: "@scope/module", version: "1.2.4" },
@@ -67,9 +67,9 @@ Deno.test("getPackage() calculates patch version update", async () => {
   await repo.commit("initial", { allowEmpty: true });
   const tag = await repo.tag("module@1.2.3");
   const commit = await repo.commit("fix(module): patch", { allowEmpty: true });
-  const pkg = await getPackage({ directory: repo.directory });
+  const pkg = await getPackage({ directory: repo.path() });
   assertEquals(pkg, {
-    directory: repo.directory,
+    directory: repo.path(),
     module: "module",
     version: `1.2.4-pre.1+${commit.short}`,
     config: { name: "@scope/module", version: "1.2.3" },
@@ -88,9 +88,9 @@ Deno.test("getPackage() calculates minor version update", async () => {
   await repo.commit("initial", { allowEmpty: true });
   const tag = await repo.tag("module@1.2.3");
   const commit = await repo.commit("feat(module): minor", { allowEmpty: true });
-  const pkg = await getPackage({ directory: repo.directory });
+  const pkg = await getPackage({ directory: repo.path() });
   assertEquals(pkg, {
-    directory: repo.directory,
+    directory: repo.path(),
     module: "module",
     version: `1.3.0-pre.1+${commit.short}`,
     config: { name: "@scope/module", version: "1.2.3" },
@@ -111,9 +111,9 @@ Deno.test("getPackage() calculates major version update", async () => {
   const commit = await repo.commit("feat(module)!: major", {
     allowEmpty: true,
   });
-  const pkg = await getPackage({ directory: repo.directory });
+  const pkg = await getPackage({ directory: repo.path() });
   assertEquals(pkg, {
-    directory: repo.directory,
+    directory: repo.path(),
     module: "module",
     version: `2.0.0-pre.1+${commit.short}`,
     config: { name: "@scope/module", version: "1.2.3" },
@@ -134,9 +134,9 @@ Deno.test("getPackage() handles multiple commits in changelog", async () => {
   const commit1 = await repo.commit("fix(module): 1", { allowEmpty: true });
   const commit2 = await repo.commit("feat(module): 2", { allowEmpty: true });
   const commit3 = await repo.commit("fix(module): 3", { allowEmpty: true });
-  const pkg = await getPackage({ directory: repo.directory });
+  const pkg = await getPackage({ directory: repo.path() });
   assertEquals(pkg, {
-    directory: repo.directory,
+    directory: repo.path(),
     module: "module",
     version: `1.3.0-pre.3+${commit3.short}`,
     config: { name: "@scope/module", version: "1.2.3" },
@@ -158,9 +158,9 @@ Deno.test("getPackage() handles forced patch update", async () => {
   await createPackage(repo.path(), { name: "@scope/module", version: "1.2.4" });
   await repo.commit("initial", { allowEmpty: true });
   const tag = await repo.tag("module@1.2.3");
-  const pkg = await getPackage({ directory: repo.directory });
+  const pkg = await getPackage({ directory: repo.path() });
   assertEquals(pkg, {
-    directory: repo.directory,
+    directory: repo.path(),
     module: "module",
     version: "1.2.4",
     config: { name: "@scope/module", version: "1.2.4" },
@@ -174,9 +174,9 @@ Deno.test("getPackage() handles forced minor update", async () => {
   await createPackage(repo.path(), { name: "@scope/module", version: "1.3.0" });
   await repo.commit("initial", { allowEmpty: true });
   const tag = await repo.tag("module@1.2.3");
-  const pkg = await getPackage({ directory: repo.directory });
+  const pkg = await getPackage({ directory: repo.path() });
   assertEquals(pkg, {
-    directory: repo.directory,
+    directory: repo.path(),
     module: "module",
     version: "1.3.0",
     config: { name: "@scope/module", version: "1.3.0" },
@@ -190,9 +190,9 @@ Deno.test("getPackage() handles forced major update", async () => {
   await createPackage(repo.path(), { name: "@scope/module", version: "2.0.0" });
   await repo.commit("initial", { allowEmpty: true });
   const tag = await repo.tag("module@1.2.3");
-  const pkg = await getPackage({ directory: repo.directory });
+  const pkg = await getPackage({ directory: repo.path() });
   assertEquals(pkg, {
-    directory: repo.directory,
+    directory: repo.path(),
     module: "module",
     version: "2.0.0",
     config: { name: "@scope/module", version: "2.0.0" },
@@ -209,9 +209,9 @@ Deno.test("getPackage() overrides calculated update", async () => {
   const commit = await repo.commit("fix(module): description", {
     allowEmpty: true,
   });
-  const pkg = await getPackage({ directory: repo.directory });
+  const pkg = await getPackage({ directory: repo.path() });
   assertEquals(pkg, {
-    directory: repo.directory,
+    directory: repo.path(),
     module: "module",
     version: "2.2.2",
     config: { name: "@scope/module", version: "2.2.2" },
@@ -229,16 +229,16 @@ Deno.test("getPackage() returns rejects forced downgrade", async () => {
   await createPackage(repo.path(), { name: "@scope/module", version: "1.2.0" });
   await repo.commit("initial", { allowEmpty: true });
   await repo.tag("module@1.2.4");
-  await assertRejects(() => getPackage({ directory: repo.directory }));
+  await assertRejects(() => getPackage({ directory: repo.path() }));
 });
 
 Deno.test("getPackage() returns empty release tag at initial version", async () => {
   await using repo = await tempRepo();
   await createPackage(repo.path(), { name: "@scope/module", version: "0.0.0" });
   await repo.commit("initial", { allowEmpty: true });
-  const pkg = await getPackage({ directory: repo.directory });
+  const pkg = await getPackage({ directory: repo.path() });
   assertEquals(pkg, {
-    directory: repo.directory,
+    directory: repo.path(),
     module: "module",
     version: "0.0.0",
     config: { name: "@scope/module", version: "0.0.0" },
@@ -250,9 +250,9 @@ Deno.test("getPackage() returns update at initial version", async () => {
   await using repo = await tempRepo();
   await createPackage(repo.path(), { name: "@scope/module", version: "0.1.0" });
   await repo.commit("feat(module): introduce module", { allowEmpty: true });
-  const pkg = await getPackage({ directory: repo.directory });
+  const pkg = await getPackage({ directory: repo.path() });
   assertEquals(pkg, {
-    directory: repo.directory,
+    directory: repo.path(),
     module: "module",
     version: "0.1.0",
     config: { name: "@scope/module", version: "0.1.0" },


### PR DESCRIPTION
It can be retrieved with `Git.path()`.