### PR TITLE
fix(pool)!: refine `pool` interface

### DIFF
--- a/core/async/mod.ts
+++ b/core/async/mod.ts
@@ -9,7 +9,8 @@
  * import { assertEquals } from "jsr:@std/assert";
  *
  * const results = await pool(
- *   [Promise.resolve(1), Promise.resolve(2), Promise.resolve(3)],
+ *   [1, 2, 3],
+ *   (x) => Promise.resolve(x),
  *   { concurrency: 2 },
  * );
  * assertEquals(results, [1, 2, 3]);

--- a/core/async/pool.test.ts
+++ b/core/async/pool.test.ts
@@ -1,40 +1,150 @@
 import { pool } from "@roka/async/pool";
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertRejects } from "@std/assert";
 
 Deno.test("pool() resolves promises with default concurrency", async () => {
-  const promises = [Promise.resolve(1), Promise.resolve(2), Promise.resolve(3)];
-  const results = await pool(promises);
+  const order: number[] = [];
+  const array = [
+    () => {
+      order.push(1);
+      return Promise.resolve(1);
+    },
+    () => {
+      order.push(2);
+      return Promise.resolve(2);
+    },
+    () => {
+      order.push(3);
+      return Promise.resolve(3);
+    },
+  ];
+  const results = await pool(array, { concurrency: 1 });
   assertEquals(results, [1, 2, 3]);
 });
 
 Deno.test("pool() resolves promises with specified concurrency", async () => {
-  const promises = [Promise.resolve(1), Promise.resolve(2), Promise.resolve(3)];
-  const results = await pool(promises, { concurrency: 2 });
+  const order: number[] = [];
+  const array = [
+    () => {
+      order.push(1);
+      return Promise.resolve(1);
+    },
+    () => {
+      order.push(2);
+      return Promise.resolve(2);
+    },
+    () => {
+      order.push(3);
+      return Promise.resolve(3);
+    },
+  ];
+  const results = await pool(array, { concurrency: 1 });
   assertEquals(results, [1, 2, 3]);
 });
 
 Deno.test("pool() handles empty array", async () => {
-  const promises: Promise<number>[] = [];
-  const results = await pool(promises);
+  const array: (() => Promise<number>)[] = [];
+  const results = await pool(array);
+  assertEquals(results, []);
+});
+
+Deno.test("pool() map handles empty array", async () => {
+  const array: (() => Promise<number>)[] = [];
+  const results = await pool(array, (x) => x());
   assertEquals(results, []);
 });
 
 Deno.test("pool() handles iterable", async () => {
+  const order: number[] = [];
   function* generator() {
-    yield Promise.resolve(1);
-    yield Promise.resolve(2);
-    yield Promise.resolve(3);
+    yield () => {
+      order.push(1);
+      return Promise.resolve(1);
+    };
+    yield () => {
+      order.push(2);
+      return Promise.resolve(2);
+    };
+    yield () => {
+      order.push(3);
+      return Promise.resolve(3);
+    };
   }
   const results = await pool(generator());
   assertEquals(results, [1, 2, 3]);
 });
 
+Deno.test("pool() map handles iterable", async () => {
+  const order: number[] = [];
+  function* generator() {
+    yield 1;
+    yield 2;
+    yield 3;
+  }
+  const results = await pool(generator(), (x) => {
+    order.push(x);
+    return Promise.resolve(x);
+  });
+  assertEquals(results, [1, 2, 3]);
+});
+
 Deno.test("pool() handles async iterable", async () => {
+  const order: number[] = [];
+  async function* asyncGenerator() {
+    order.push(1);
+    yield Promise.resolve(1);
+    order.push(2);
+    yield Promise.resolve(2);
+    order.push(3);
+    yield Promise.resolve(3);
+  }
+  const results = await pool(asyncGenerator());
+  assertEquals(results, [1, 2, 3]);
+  assertEquals(order, [1, 2, 3]);
+});
+
+Deno.test("pool() map handles async iterable", async () => {
+  const order: number[] = [];
+  async function* asyncGenerator() {
+    yield 1;
+    yield 2;
+    yield 3;
+  }
+  const results = await pool(asyncGenerator(), (x) => {
+    order.push(x);
+    return Promise.resolve(x);
+  });
+  assertEquals(results, [1, 2, 3]);
+  assertEquals(order, [1, 2, 3]);
+});
+
+Deno.test("pool() map handles async iterable of promises", async () => {
+  const order: number[] = [];
   async function* asyncGenerator() {
     yield Promise.resolve(1);
     yield Promise.resolve(2);
     yield Promise.resolve(3);
   }
-  const results = await pool(asyncGenerator());
+  const results = await pool(asyncGenerator(), (x) => {
+    order.push(x);
+    return Promise.resolve(x);
+  });
   assertEquals(results, [1, 2, 3]);
+  assertEquals(order, [1, 2, 3]);
+});
+
+Deno.test("pool() throws AggregateError on error", async () => {
+  const array = [
+    () => Promise.resolve(1),
+    () => Promise.reject(new Error("error")),
+    () => Promise.resolve(3),
+  ];
+  await assertRejects(() => pool(array), AggregateError);
+});
+
+Deno.test("pool() rejects iterable of promises", async () => {
+  const array = [Promise.resolve(1), Promise.resolve(2)];
+  await assertRejects(
+    () => pool(array as unknown as Iterable<() => Promise<number>>),
+    AggregateError,
+  );
 });

--- a/core/async/pool.ts
+++ b/core/async/pool.ts
@@ -1,16 +1,47 @@
 /**
  * Pooling functions for async iterables.
  *
+ * This modules provides the {@linkcode pool} function which can be used to
+ * resolve a iterable of promises, limiting the maximum amount of concurrency.
+ *
+ * The function support sevaral variants.
+ *
+ * @example
+ * ```ts
+ * import { pool } from "@roka/async/pool";
+ * import { assertEquals } from "jsr:@std/assert";
+ *
+ * // resolves an iterable of functions that return promises
+ * await pool([() => Promise.resolve(1), () => Promise.resolve(2)]);
+ * // resolve an iterable mapped to promises
+ * await pool([1, 2, 3], (x) => Promise.resolve(x * 2));
+ * // resolves an async iterable
+ * async function* promiseGenerator() { yield Promise.resolve(1); }
+ * await pool(promiseGenerator());
+ * // resolves an async iterable mapped to promises
+ * async function* generator() { yield Promise.resolve(1); }
+ * await pool(generator(), (x) => Promise.resolve(x * 2));
+ * ```
+ *
+ * The accepted input types make sure that the async execution whose concurrency
+ * is to be limited starts only when the function is called. The concurrency
+ * is not limited by default, but can be set using the `concurrency` option.
+ *
+ * If an error is thrown from a function, no new executions will begin. All
+ * currently executing functions are allowed to finish and still yielded on
+ * success. After that, the rejections among them are gathered and thrown by the
+ * iterator in an `AggregateError`.
+ *
  * @module
  */
 
-import { pooledMap } from "@std/async";
+import { pooledMap } from "@std/async/pool";
 
 /** Options for the pool function. */
 export interface PoolOptions {
   /**
    * The maximum number of concurrent operations.
-   * {@default 1}
+   * {@default Infinity}
    */
   concurrency?: number;
 }
@@ -18,15 +49,20 @@ export interface PoolOptions {
 /**
  * Resolves a iterable of promises, limiting the maximum amount of concurrency.
  *
- * @example with iterables of promises
+ * @example with iterables of promise functions
  * ```ts
  * import { pool } from "@roka/async/pool";
  * import { assertEquals } from "jsr:@std/assert";
  *
  * const results = await pool(
- *   [Promise.resolve(1), Promise.resolve(2), Promise.resolve(3)],
+ *   [
+ *     () => Promise.resolve(1),
+ *     () => Promise.resolve(2),
+ *     () => Promise.resolve(3)
+ *   ],
  *   { concurrency: 2 },
  * );
+ *
  * assertEquals(results, [1, 2, 3]);
  * ```
  *
@@ -40,18 +76,81 @@ export interface PoolOptions {
  *   yield Promise.resolve(2);
  *   yield Promise.resolve(3);
  * }
+ * const results = await pool(asyncGenerator(), { concurrency: 2 });
  *
- * const results = await pool(asyncGenerator());
  * assertEquals(results, [1, 2, 3]);
  * ```
  */
 export async function pool<T>(
-  array: Iterable<Promise<T>> | AsyncIterable<T>,
-  { concurrency = 1 } = {},
-): Promise<T[]> {
+  array: Iterable<() => Promise<T>> | AsyncIterable<T>,
+  options?: PoolOptions,
+): Promise<T[]>;
+/**
+ * Transforms values to an iterable of promises, and resolves them limiting the
+ * maximum amount of concurrency.
+ *
+ * @example with iterables
+ * ```ts
+ * import { pool } from "@roka/async/pool";
+ * import { assertEquals } from "jsr:@std/assert";
+ *
+ * const results = await pool(
+ *   [1, 2, 3],
+ *   (value) => Promise.resolve(value * 2),
+ *   { concurrency: 2 },
+ * );
+ *
+ * assertEquals(results, [2, 4, 6]);
+ * ```
+ *
+ * @example with async iterables
+ * ```ts
+ * import { pool } from "@roka/async/pool";
+ * import { assertEquals } from "jsr:@std/assert";
+ *
+ * async function* asyncGenerator() {
+ *   yield 1;
+ *   yield 2;
+ *   yield 3;
+ * }
+ * const results = await pool(
+ *   asyncGenerator(),
+ *   (value) => Promise.resolve(value * 2),
+ *   { concurrency: 2 },
+ * );
+ *
+ * assertEquals(results, [2, 4, 6]);
+ * ```
+ */
+export async function pool<T, R>(
+  array: Iterable<T> | AsyncIterable<T>,
+  iteratorFn: (value: T) => Promise<R>,
+  options?: PoolOptions,
+): Promise<R[]>;
+
+export async function pool<T, R>(
+  array: Iterable<() => Promise<T>> | AsyncIterable<T> | Iterable<T>,
+  iteratorFnOrOptions?: ((value: T) => Promise<R>) | PoolOptions,
+  options?: PoolOptions,
+): Promise<(T | R)[]> {
+  if (typeof iteratorFnOrOptions === "function") {
+    const { concurrency = Infinity } = options ?? {};
+    return await Array.fromAsync(
+      pooledMap(
+        concurrency,
+        array as Iterable<T> | AsyncIterable<T>,
+        iteratorFnOrOptions,
+      ),
+    );
+  }
+  const { concurrency = Infinity } = iteratorFnOrOptions ?? {};
   return await Array.fromAsync(
     Symbol.asyncIterator in array
       ? pooledMap(concurrency, array, (x) => Promise.resolve(x))
-      : pooledMap(concurrency, array, (x) => x),
+      : pooledMap(
+        concurrency,
+        array as Iterable<() => Promise<T>>,
+        (x) => x(),
+      ),
   );
 }

--- a/tool/forge/cli.ts
+++ b/tool/forge/cli.ts
@@ -36,11 +36,15 @@ function compileCommand(targets: string[]) {
     .action(async (options, ...filters) => {
       const packages = (await workspace({ filters }))
         .filter((pkg) => pkg.config.compile);
-      await pool(packages.map(async (pkg) => {
-        const artifacts = await compile(pkg, options);
-        console.log(`📦 Compiled ${pkg.module}`);
-        artifacts.forEach((artifact) => console.log("🏺", artifact));
-      }, options));
+      await pool(
+        packages,
+        async (pkg) => {
+          const artifacts = await compile(pkg, options);
+          console.log(`📦 Compiled ${pkg.module}`);
+          artifacts.forEach((artifact) => console.log("🏺", artifact));
+        },
+        options,
+      );
     });
 }
 
@@ -82,11 +86,11 @@ function releaseCommand() {
     .action(async (options, ...filters) => {
       const packages = (await workspace({ filters }))
         .filter((pkg) => pkg.config.version !== pkg.release?.version);
-      await pool(packages.map(async (pkg) => {
+      await pool(packages, async (pkg) => {
         const [rls, assets] = await release(pkg, options);
         console.log(`🚀 Released ${pkg.module} [${rls.url}]`);
         assets.forEach((x) => console.log(`🏺 ${x.name} [${x.url}]`));
-      }));
+      }, { concurrency: 1 });
     });
 }
 

--- a/tool/forge/compile.ts
+++ b/tool/forge/compile.ts
@@ -76,7 +76,8 @@ export async function compile(
   if (version) pkg.config.version = version;
   await Deno.writeTextFile(config, JSON.stringify(pkg.config, null, 2));
   const artifacts = await pool(
-    target.map(async (target) => {
+    target,
+    async (target) => {
       const output = join(directory, target, pkg.module);
       const args = [
         "compile",
@@ -114,7 +115,7 @@ export async function compile(
       const bundle = `${build}.${isWindows ? "zip" : "tar.gz"}`;
       await (isWindows ? zip : tar)(build, bundle);
       return bundle;
-    }),
+    },
     { concurrency },
   );
   if (options?.checksum) {

--- a/tool/forge/release.ts
+++ b/tool/forge/release.ts
@@ -89,7 +89,7 @@ export async function upload(
 ): Promise<ReleaseAsset[]> {
   // delete existing assets first
   const assets = await release.assets.list();
-  await pool(assets.map((asset) => asset.delete()), GITHUB_CONCURRENCY);
+  await pool(assets, (asset) => asset.delete(), GITHUB_CONCURRENCY);
   const artifacts = pkg.config.compile
     ? await compile(pkg, {
       target: await targets(),
@@ -99,7 +99,8 @@ export async function upload(
     })
     : [];
   return await pool(
-    artifacts.map((artifact) => release.assets.upload(artifact)),
+    artifacts,
+    (artifact) => release.assets.upload(artifact),
     GITHUB_CONCURRENCY,
   );
 }


### PR DESCRIPTION
Iterable of promise is not accepted, instead an optional mapping fn is accepted to transform lists into promises. Async iterables of promises are still accepted.

Changing the default concurrency to infinity, and it is the least surprising behavior.