### PR TITLE
feat(async): add `pooled` function to `pool` module

### DIFF
--- a/core/async/mod.ts
+++ b/core/async/mod.ts
@@ -1,7 +1,7 @@
 /**
  * Helpers for concurrency.
  *
- * Currently, the only function provided is {@link pool}.
+ * Currently, the only submodule provided is `pool`.
  *
  * @example
  * ```ts

--- a/core/async/pool.test.ts
+++ b/core/async/pool.test.ts
@@ -1,27 +1,27 @@
-import { pool } from "@roka/async/pool";
+import { pool, pooled } from "@roka/async/pool";
 import { assertEquals, assertRejects } from "@std/assert";
 
 Deno.test("pool() resolves promises with default concurrency", async () => {
-  const order: number[] = [];
   const array = [
-    () => {
-      order.push(1);
-      return Promise.resolve(1);
-    },
-    () => {
-      order.push(2);
-      return Promise.resolve(2);
-    },
-    () => {
-      order.push(3);
-      return Promise.resolve(3);
-    },
+    () => Promise.resolve(1),
+    () => Promise.resolve(2),
+    () => Promise.resolve(3),
   ];
-  const results = await pool(array, { concurrency: 1 });
+  const results = await pool(array);
   assertEquals(results, [1, 2, 3]);
 });
 
 Deno.test("pool() resolves promises with specified concurrency", async () => {
+  const array = [
+    () => Promise.resolve(1),
+    () => Promise.resolve(2),
+    () => Promise.resolve(3),
+  ];
+  const results = await pool(array, { concurrency: 2 });
+  assertEquals(results, [1, 2, 3]);
+});
+
+Deno.test("pool() maintains execution order", async () => {
   const order: number[] = [];
   const array = [
     () => {
@@ -37,8 +37,8 @@ Deno.test("pool() resolves promises with specified concurrency", async () => {
       return Promise.resolve(3);
     },
   ];
-  const results = await pool(array, { concurrency: 1 });
-  assertEquals(results, [1, 2, 3]);
+  await pool(array, { concurrency: 1 });
+  assertEquals(order, [1, 2, 3]);
 });
 
 Deno.test("pool() handles empty array", async () => {
@@ -54,82 +54,53 @@ Deno.test("pool() map handles empty array", async () => {
 });
 
 Deno.test("pool() handles iterable", async () => {
-  const order: number[] = [];
   function* generator() {
-    yield () => {
-      order.push(1);
-      return Promise.resolve(1);
-    };
-    yield () => {
-      order.push(2);
-      return Promise.resolve(2);
-    };
-    yield () => {
-      order.push(3);
-      return Promise.resolve(3);
-    };
+    yield () => Promise.resolve(1);
+    yield () => Promise.resolve(2);
+    yield () => Promise.resolve(3);
   }
   const results = await pool(generator());
   assertEquals(results, [1, 2, 3]);
 });
 
 Deno.test("pool() map handles iterable", async () => {
-  const order: number[] = [];
   function* generator() {
     yield 1;
     yield 2;
     yield 3;
   }
-  const results = await pool(generator(), (x) => {
-    order.push(x);
-    return Promise.resolve(x);
-  });
+  const results = await pool(generator(), (x) => Promise.resolve(x));
   assertEquals(results, [1, 2, 3]);
 });
 
 Deno.test("pool() handles async iterable", async () => {
-  const order: number[] = [];
   async function* asyncGenerator() {
-    order.push(1);
     yield Promise.resolve(1);
-    order.push(2);
     yield Promise.resolve(2);
-    order.push(3);
     yield Promise.resolve(3);
   }
   const results = await pool(asyncGenerator());
   assertEquals(results, [1, 2, 3]);
-  assertEquals(order, [1, 2, 3]);
 });
 
 Deno.test("pool() map handles async iterable", async () => {
-  const order: number[] = [];
   async function* asyncGenerator() {
     yield 1;
     yield 2;
     yield 3;
   }
-  const results = await pool(asyncGenerator(), (x) => {
-    order.push(x);
-    return Promise.resolve(x);
-  });
+  const results = await pool(asyncGenerator(), (x) => Promise.resolve(x));
   assertEquals(results, [1, 2, 3]);
-  assertEquals(order, [1, 2, 3]);
 });
 
 Deno.test("pool() map handles async iterable of promises", async () => {
-  const order: number[] = [];
   async function* asyncGenerator() {
     yield Promise.resolve(1);
     yield Promise.resolve(2);
     yield Promise.resolve(3);
   }
-  const results = await pool(asyncGenerator(), (x) => {
-    order.push(x);
-    return Promise.resolve(x);
-  });
+  const results = await pool(asyncGenerator(), (x) => Promise.resolve(x));
   assertEquals(results, [1, 2, 3]);
-  assertEquals(order, [1, 2, 3]);
 });
 
 Deno.test("pool() throws AggregateError on error", async () => {
@@ -145,6 +116,136 @@ Deno.test("pool() rejects iterable of promises", async () => {
   const array = [Promise.resolve(1), Promise.resolve(2)];
   await assertRejects(
     () => pool(array as unknown as Iterable<() => Promise<number>>),
+    AggregateError,
+  );
+});
+
+Deno.test("pooled() resolves promises with default concurrency", async () => {
+  const array = [
+    () => Promise.resolve(1),
+    () => Promise.resolve(2),
+    () => Promise.resolve(3),
+  ];
+  const results: number[] = [];
+  for await (const x of pooled(array)) results.push(x);
+  assertEquals(results, [1, 2, 3]);
+});
+
+Deno.test("pooled() resolves promises with specified concurrency", async () => {
+  const array = [
+    () => Promise.resolve(1),
+    () => Promise.resolve(2),
+    () => Promise.resolve(3),
+  ];
+  const results: number[] = [];
+  for await (const x of pooled(array, { concurrency: 2 })) results.push(x);
+  assertEquals(results, [1, 2, 3]);
+});
+
+Deno.test("pooled() maintains execution order", async () => {
+  const order: number[] = [];
+  const array = [
+    () => {
+      order.push(1);
+      return Promise.resolve(1);
+    },
+    () => {
+      order.push(2);
+      return Promise.resolve(2);
+    },
+    () => {
+      order.push(3);
+      return Promise.resolve(3);
+    },
+  ];
+  await Array.fromAsync(pooled(array));
+  assertEquals(order, [1, 2, 3]);
+});
+
+Deno.test("pooled() handles empty array", async () => {
+  const array: (() => Promise<number>)[] = [];
+  const results = await Array.fromAsync(pooled(array));
+  assertEquals(results, []);
+});
+
+Deno.test("pooled() map handles empty array", async () => {
+  const array: (() => Promise<number>)[] = [];
+  const results = await Array.fromAsync(pooled(array));
+  assertEquals(results, []);
+});
+
+Deno.test("pooled() handles iterable", async () => {
+  function* generator() {
+    yield () => Promise.resolve(1);
+    yield () => Promise.resolve(2);
+    yield () => Promise.resolve(3);
+  }
+  const results = await Array.fromAsync(pooled(generator()));
+  assertEquals(results, [1, 2, 3]);
+});
+
+Deno.test("pooled() map handles iterable", async () => {
+  function* generator() {
+    yield 1;
+    yield 2;
+    yield 3;
+  }
+  const results = await Array.fromAsync(
+    pooled(generator(), (x) => Promise.resolve(x)),
+  );
+  assertEquals(results, [1, 2, 3]);
+});
+
+Deno.test("pooled() handles async iterable", async () => {
+  async function* asyncGenerator() {
+    yield Promise.resolve(1);
+    yield Promise.resolve(2);
+    yield Promise.resolve(3);
+  }
+  const results = await Array.fromAsync(pooled(asyncGenerator()));
+  assertEquals(results, [1, 2, 3]);
+});
+
+Deno.test("pooled() map handles async iterable", async () => {
+  async function* asyncGenerator() {
+    yield 1;
+    yield 2;
+    yield 3;
+  }
+  const results = await Array.fromAsync(
+    pooled(asyncGenerator(), (x) => Promise.resolve(x)),
+  );
+  assertEquals(results, [1, 2, 3]);
+});
+
+Deno.test("pooled() map handles async iterable of promises", async () => {
+  async function* asyncGenerator() {
+    yield Promise.resolve(1);
+    yield Promise.resolve(2);
+    yield Promise.resolve(3);
+  }
+  const results = await Array.fromAsync(
+    pooled(asyncGenerator(), (x) => Promise.resolve(x)),
+  );
+  assertEquals(results, [1, 2, 3]);
+});
+
+Deno.test("pooled() throws AggregateError on error", async () => {
+  const array = [
+    () => Promise.resolve(1),
+    () => Promise.reject(new Error("error")),
+    () => Promise.resolve(3),
+  ];
+  await assertRejects(() => Array.fromAsync(pooled(array)), AggregateError);
+});
+
+Deno.test("pooled() rejects iterable of promises", async () => {
+  const array = [Promise.resolve(1), Promise.resolve(2)];
+  await assertRejects(
+    () =>
+      Array.fromAsync(
+        pooled(array as unknown as Iterable<() => Promise<number>>),
+      ),
     AggregateError,
   );
 });

--- a/core/async/pool.ts
+++ b/core/async/pool.ts
@@ -1,7 +1,7 @@
 /**
  * Pooling functions for async iterables.
  *
- * This modules provides the {@linkcode pool} and {@linkcode pooled} functions
+ * This module provides the {@linkcode pool} and {@linkcode pooled} functions
  * which can be used to resolve a collection of promises, limiting the maximum
  * amount of concurrency. The former returns an array of results, while the
  * latter returns an async iterable.

--- a/core/async/pool.ts
+++ b/core/async/pool.ts
@@ -1,10 +1,12 @@
 /**
  * Pooling functions for async iterables.
  *
- * This modules provides the {@linkcode pool} function which can be used to
- * resolve a collection of promises, limiting the maximum amount of concurrency.
+ * This modules provides the {@linkcode pool} and {@linkcode pooled} functions
+ * which can be used to resolve a collection of promises, limiting the maximum
+ * amount of concurrency. The former returns an array of results, while the
+ * latter returns an async iterable.
  *
- * The function support several variants.
+ * The functions accept several input variants.
  *
  * @example
  * ```ts
@@ -36,6 +38,9 @@
  * success. After that, the rejections among them are gathered and thrown by the
  * iterator in an `AggregateError`.
  *
+ * This module is a thin wrapper around the `pooledMap` function from the
+ * `@std/async/pool` standard library module, providing a more convenient API.
+ *
  * @module
  */
 
@@ -51,7 +56,8 @@ export interface PoolOptions {
 }
 
 /**
- * Resolves a iterable of promises, limiting the maximum amount of concurrency.
+ * Resolves a iterable of promises, and returns the results as an array,
+ * while limiting the maximum amount of concurrency.
  *
  * @example with iterables of promise functions
  * ```ts
@@ -90,8 +96,8 @@ export async function pool<T>(
   options?: PoolOptions,
 ): Promise<T[]>;
 /**
- * Transforms values to an iterable of promises, and resolves them limiting the
- * maximum amount of concurrency.
+ * Transforms values to an iterable of promises, resolves them, and returns the
+ * results as an array while limiting the maximum amount of concurrency.
  *
  * @example with iterables
  * ```ts
@@ -137,24 +143,130 @@ export async function pool<T, R>(
   iteratorFnOrOptions?: ((value: T) => Promise<R>) | PoolOptions,
   options?: PoolOptions,
 ): Promise<(T | R)[]> {
-  if (typeof iteratorFnOrOptions === "function") {
-    const { concurrency = Infinity } = options ?? {};
+  if (typeof iteratorFnOrOptions !== "function") {
     return await Array.fromAsync(
-      pooledMap(
-        concurrency,
-        array as Iterable<T> | AsyncIterable<T>,
-        iteratorFnOrOptions,
-      ),
+      Symbol.asyncIterator in array
+        ? pooled(array, iteratorFnOrOptions)
+        : pooled(array as Iterable<() => Promise<T>>, options),
     );
   }
-  const { concurrency = Infinity } = iteratorFnOrOptions ?? {};
-  return await Array.fromAsync(
-    Symbol.asyncIterator in array
-      ? pooledMap(concurrency, array, (x) => Promise.resolve(x))
-      : pooledMap(
-        concurrency,
+  return await Array.fromAsync(pooled(
+    array as Iterable<T> | AsyncIterable<T>,
+    iteratorFnOrOptions,
+    options,
+  ));
+}
+
+/**
+ * Resolves a iterable of promises, and yields the results as an async iterable,
+ * while limiting the maximum amount of concurrency.
+ *
+ * @example with iterables of promise functions
+ * ```ts
+ * import { pool } from "@roka/async/pool";
+ * import { assertEquals } from "jsr:@std/assert";
+ *
+ * const results = await pool(
+ *   [
+ *     () => Promise.resolve(1),
+ *     () => Promise.resolve(2),
+ *     () => Promise.resolve(3)
+ *   ],
+ *   { concurrency: 2 },
+ * );
+ *
+ * assertEquals(results, [1, 2, 3]);
+ * ```
+ *
+ * @example with async iterables
+ * ```ts
+ * import { pool } from "@roka/async/pool";
+ * import { assertEquals } from "jsr:@std/assert";
+ *
+ * async function* asyncGenerator() {
+ *   yield Promise.resolve(1);
+ *   yield Promise.resolve(2);
+ *   yield Promise.resolve(3);
+ * }
+ * const results = await pool(asyncGenerator(), { concurrency: 2 });
+ *
+ * assertEquals(results, [1, 2, 3]);
+ * ```
+ */
+export function pooled<T>(
+  array: Iterable<() => Promise<T>> | AsyncIterable<T>,
+  options?: PoolOptions,
+): AsyncIterableIterator<T>;
+/**
+ * Transforms values to an iterable of promises, resolves them, and yields the
+ * results as an async iterable while limiting the maximum amount of
+ * concurrency.
+ *
+ * @example with iterables
+ * ```ts
+ * import { pooled } from "@roka/async/pool";
+ * import { assertEquals } from "jsr:@std/assert";
+ *
+ * const results: number[] = [];
+ * const iterable = pooled(
+ *   [1, 2, 3],
+ *   (value) => Promise.resolve(value * 2),
+ *   { concurrency: 2 },
+ * );
+ * for await (const number of iterable) {
+ *   results.push(number);
+ * }
+ *
+ * assertEquals(results, [2, 4, 6]);
+ * ```
+ *
+ * @example with async iterables
+ * ```ts
+ * import { pooled } from "@roka/async/pool";
+ * import { assertEquals } from "jsr:@std/assert";
+ *
+ * const results: number[] = [];
+ * async function* asyncGenerator() {
+ *   yield 1;
+ *   yield 2;
+ *   yield 3;
+ * }
+ * const iterable = pooled(
+ *   asyncGenerator(),
+ *   (value) => Promise.resolve(value * 2),
+ *   { concurrency: 2 },
+ * );
+ * for await (const number of iterable) {
+ *   results.push(number);
+ * }
+ *
+ * assertEquals(results, [2, 4, 6]);
+ * ```
+ */
+export function pooled<T, R>(
+  array: Iterable<T> | AsyncIterable<T>,
+  iteratorFn: (value: T) => Promise<R>,
+  options?: PoolOptions,
+): AsyncIterableIterator<R>;
+
+export function pooled<T, R>(
+  array: Iterable<() => Promise<T>> | AsyncIterable<T> | Iterable<T>,
+  iteratorFnOrOptions?: ((value: T) => Promise<R>) | PoolOptions,
+  options?: PoolOptions,
+): AsyncIterableIterator<T | R> {
+  if (typeof iteratorFnOrOptions !== "function") {
+    return Symbol.asyncIterator in array
+      ? pooled(array, (x) => Promise.resolve(x), iteratorFnOrOptions)
+      : pooled(
         array as Iterable<() => Promise<T>>,
         (x) => x(),
-      ),
+        iteratorFnOrOptions,
+      );
+  }
+  const { concurrency = Infinity } = options ?? {};
+  return pooledMap(
+    concurrency,
+    array as Iterable<T> | AsyncIterable<T>,
+    iteratorFnOrOptions,
   );
 }


### PR DESCRIPTION
This provides the same interface as `pool`, but provides the same trade-off of convenience and performance with `pooledMap` from the standard library.