### PR TITLE
style: consistent imports

### DIFF
--- a/core/git/git.test.ts
+++ b/core/git/git.test.ts
@@ -1,6 +1,6 @@
 import { git, GitError } from "@roka/git";
 import { tempRepository } from "@roka/git/testing";
-import { tempDirectory } from "@roka/testing";
+import { tempDirectory } from "@roka/testing/temp";
 import {
   assertEquals,
   assertExists,

--- a/core/git/git.ts
+++ b/core/git/git.ts
@@ -59,8 +59,7 @@
  */
 
 import { assert, assertEquals, assertFalse, assertGreater } from "@std/assert";
-import { basename } from "@std/path/basename";
-import { join } from "@std/path/join";
+import { basename, join } from "@std/path";
 
 /** An error while running a git command. */
 export class GitError extends Error {

--- a/core/github/github.ts
+++ b/core/github/github.ts
@@ -22,7 +22,7 @@
 import type { components } from "@octokit/openapi-types/types";
 import { Octokit } from "@octokit/rest";
 import { type Git, git as gitRepo } from "@roka/git";
-import { assert } from "@std/assert/assert";
+import { assert } from "@std/assert";
 import { basename } from "@std/path";
 
 /** GitHub API client. */

--- a/core/github/testing.ts
+++ b/core/github/testing.ts
@@ -26,7 +26,7 @@ import type {
   ReleaseAsset,
   Repository,
 } from "@roka/github";
-import { basename } from "@std/path/basename";
+import { basename } from "@std/path";
 
 /**
  * Creates a repository with fake data.

--- a/core/http/request.ts
+++ b/core/http/request.ts
@@ -4,12 +4,12 @@
  * @module
  */
 
-import { assert } from "@std/assert/assert";
+import { assert } from "@std/assert";
 import { retry, type RetryOptions } from "@std/async/retry";
-import { omit } from "@std/collections/omit";
+import { omit } from "@std/collections";
 import { STATUS_CODE } from "@std/http/status";
 
-export { type RetryOptions } from "@std/async";
+export { type RetryOptions } from "@std/async/retry";
 
 /** Predefined agent strings. */
 export const AGENT = {

--- a/core/testing/mock.ts
+++ b/core/testing/mock.ts
@@ -82,7 +82,7 @@
  * @module
  */
 
-import { assert } from "@std/assert/assert";
+import { assert } from "@std/assert";
 import { dirname, fromFileUrl, parse, resolve, toFileUrl } from "@std/path";
 import {
   type GetParametersFromProp,

--- a/core/testing/temp.ts
+++ b/core/testing/temp.ts
@@ -16,7 +16,7 @@
  * @module
  */
 
-import { join } from "@std/path/join";
+import { join } from "@std/path";
 
 /** A temporary directory returned by {@linkcode tempDirectory}. */
 export interface TempDirectory extends AsyncDisposable {

--- a/tool/forge/compile.test.ts
+++ b/tool/forge/compile.test.ts
@@ -7,7 +7,7 @@ import {
   assertMatch,
   assertRejects,
 } from "@std/assert";
-import { copy } from "@std/fs/copy";
+import { copy } from "@std/fs";
 import { basename, dirname } from "@std/path";
 
 const IMPORT_MAP = {

--- a/tool/forge/compile.ts
+++ b/tool/forge/compile.ts
@@ -14,7 +14,7 @@ import {
   PackageError,
   type Permissions,
 } from "@roka/forge/package";
-import { assert } from "@std/assert/assert";
+import { assert } from "@std/assert";
 import { encodeHex } from "@std/encoding";
 import { basename, join, relative } from "@std/path";
 

--- a/tool/forge/package.test.ts
+++ b/tool/forge/package.test.ts
@@ -7,9 +7,9 @@ import {
 } from "@roka/forge/package";
 import { conventional } from "@roka/git/conventional";
 import { tempRepository } from "@roka/git/testing";
-import { tempDirectory } from "@roka/testing";
+import { tempDirectory } from "@roka/testing/temp";
 import { assertEquals, assertRejects } from "@std/assert";
-import { join } from "@std/path/join";
+import { join } from "@std/path";
 
 async function createPackage(
   directory: string,


### PR DESCRIPTION
- (mostly) shorter from @std
  - kept `http` longer beacuse it is mostly server symbols
  - kepy `async` longer because the submodules are distinct enough
- longer from @roka