### PR TITLE
refactor(github)!: rename test objects to "fake"

### DIFF
--- a/core/github/testing.test.ts
+++ b/core/github/testing.test.ts
@@ -1,20 +1,20 @@
 import { assertEquals, assertExists, assertNotEquals } from "@std/assert";
 import {
-  testPullRequest,
-  testRelease,
-  testReleaseAsset,
-  testRepository,
+  fakePullRequest,
+  fakeRelease,
+  fakeReleaseAsset,
+  fakeRepository,
 } from "./testing.ts";
 
-Deno.test("testRepository() creates a repository with default data", () => {
-  const repo = testRepository();
+Deno.test("fakeRepository() creates a repository with default data", () => {
+  const repo = fakeRepository();
   assertExists(repo.url);
   assertExists(repo.owner);
   assertExists(repo.repo);
 });
 
-Deno.test("testRepository() creates a repository with custom data", () => {
-  const repo = testRepository({
+Deno.test("fakeRepository() creates a repository with custom data", () => {
+  const repo = fakeRepository({
     url: "custom-url",
     owner: "custom-owner",
     repo: "custom-repo",
@@ -24,8 +24,8 @@ Deno.test("testRepository() creates a repository with custom data", () => {
   assertEquals(repo.repo, "custom-repo");
 });
 
-Deno.test("testRepository() manages pull requests", async () => {
-  const repo = testRepository();
+Deno.test("fakeRepository() manages pull requests", async () => {
+  const repo = fakeRepository();
   assertEquals(await repo.pulls.list(), []);
   const pull = await repo.pulls.create({ title: "test pull" });
   assertEquals(pull.title, "test pull");
@@ -36,8 +36,8 @@ Deno.test("testRepository() manages pull requests", async () => {
   assertEquals(await repo.pulls.list(), [pull, another]);
 });
 
-Deno.test("testRepository() manages releases", async () => {
-  const repo = testRepository();
+Deno.test("fakeRepository() manages releases", async () => {
+  const repo = fakeRepository();
   assertEquals(await repo.releases.list(), []);
   const release = await repo.releases.create("1.0.0");
   assertEquals(release.tag, "1.0.0");
@@ -52,8 +52,8 @@ Deno.test("testRepository() manages releases", async () => {
   assertEquals(await repo.releases.list(), []);
 });
 
-Deno.test("testPullRequest() creates a pull request with default data", () => {
-  const pull = testPullRequest();
+Deno.test("fakePullRequest() creates a pull request with default data", () => {
+  const pull = fakePullRequest();
   assertExists(pull.repo);
   assertExists(pull.url);
   assertExists(pull.number);
@@ -63,9 +63,9 @@ Deno.test("testPullRequest() creates a pull request with default data", () => {
   assertExists(pull.base);
 });
 
-Deno.test("testPullRequest() creates a pull request with custom data", () => {
-  const repo = testRepository();
-  const pull = testPullRequest({
+Deno.test("fakePullRequest() creates a pull request with custom data", () => {
+  const repo = fakeRepository();
+  const pull = fakePullRequest({
     repo,
     url: "custom-url",
     number: 42,
@@ -89,8 +89,8 @@ Deno.test("testPullRequest() creates a pull request with custom data", () => {
   assertEquals(pull.locked, true);
 });
 
-Deno.test("testPullRequest() can update data", async () => {
-  const pull = testPullRequest({ title: "title", body: "body", closed: false });
+Deno.test("fakePullRequest() can update data", async () => {
+  const pull = fakePullRequest({ title: "title", body: "body", closed: false });
   assertEquals(pull.title, "title");
   assertEquals(pull.body, "body");
   assertEquals(pull.closed, false);
@@ -100,8 +100,8 @@ Deno.test("testPullRequest() can update data", async () => {
   assertEquals(pull.closed, true);
 });
 
-Deno.test("testRelease() creates a release with default data", () => {
-  const release = testRelease();
+Deno.test("fakeRelease() creates a release with default data", () => {
+  const release = fakeRelease();
   assertExists(release.repo);
   assertExists(release.url);
   assertExists(release.id);
@@ -111,9 +111,9 @@ Deno.test("testRelease() creates a release with default data", () => {
   assertExists(release.body);
 });
 
-Deno.test("testRelease() creates a release with custom data", () => {
-  const repo = testRepository();
-  const release = testRelease({
+Deno.test("fakeRelease() creates a release with custom data", () => {
+  const repo = fakeRepository();
+  const release = fakeRelease({
     repo,
     url: "custom-url",
     id: 42,
@@ -135,8 +135,8 @@ Deno.test("testRelease() creates a release with custom data", () => {
   assertEquals(release.preRelease, true);
 });
 
-Deno.test("testRelease() can update data", async () => {
-  const release = testRelease({ tag: "tag", name: "name", draft: true });
+Deno.test("fakeRelease() can update data", async () => {
+  const release = fakeRelease({ tag: "tag", name: "name", draft: true });
   assertEquals(release.tag, "tag");
   assertEquals(release.name, "name");
   assertEquals(release.draft, true);
@@ -146,8 +146,8 @@ Deno.test("testRelease() can update data", async () => {
   assertEquals(release.draft, false);
 });
 
-Deno.test("testRelease() manages assets", async () => {
-  const release = testRelease();
+Deno.test("fakeRelease() manages assets", async () => {
+  const release = fakeRelease();
   assertEquals(await release.assets.list(), []);
   const asset = await release.assets.upload("file.txt");
   assertEquals(asset.name, "file.txt");
@@ -162,8 +162,8 @@ Deno.test("testRelease() manages assets", async () => {
   assertEquals(await release.assets.list(), []);
 });
 
-Deno.test("testReleaseAsset() creates asset with default values", () => {
-  const asset = testReleaseAsset();
+Deno.test("fakeReleaseAsset() creates asset with default values", () => {
+  const asset = fakeReleaseAsset();
   assertExists(asset.release);
   assertExists(asset.url);
   assertExists(asset.id);
@@ -172,9 +172,9 @@ Deno.test("testReleaseAsset() creates asset with default values", () => {
   assertExists(asset.downloadCount);
 });
 
-Deno.test("testReleaseAsset() creates asset with custom values", () => {
-  const release = testRelease({ tag: "custom-tag" });
-  const asset = testReleaseAsset({
+Deno.test("fakeReleaseAsset() creates asset with custom values", () => {
+  const release = fakeRelease({ tag: "custom-tag" });
+  const asset = fakeReleaseAsset({
     release,
     url: "custom-url",
     id: 42,

--- a/core/github/testing.ts
+++ b/core/github/testing.ts
@@ -1,22 +1,18 @@
 /**
- * Objects to write tests for GitHub.
- *
  * This module provides utilities to create fake GitHub objects for testing.
  *
- * @example
  * ```ts
- * import { testRepository, testPullRequest, testRelease } from "@roka/github/testing";
- * import { assertEquals } from "@std/assert";
- *
- * const repo = testRepository();
- * const pull = testPullRequest({ repo, title: "title" });
- * const release = testRelease({ repo, tag: "tag" });
- *
- * assertEquals(pull.repo, repo);
- * assertEquals(release.repo, repo);
+ * import {
+ *   fakeRepository,
+ *   fakePullRequest,
+ *   fakeRelease,
+ * } from "@roka/github/testing";
+ * const repo = fakeRepository();
+ * const pull = fakePullRequest({ repo, title: "title" });
+ * const release = fakeRelease({ repo, tag: "tag" });
  * ```
  *
- * @module
+ * @module testing
  */
 
 import { git } from "@roka/git";
@@ -29,27 +25,25 @@ import type {
 import { basename } from "@std/path";
 
 /**
- * Creates a repository with fake data.
+ * Creates a repository with fake data and operations.
  *
  * The created repository keeps track of its pull requests and releases.
  *
- * @example
+ * @example Create a repository with a pull request and a release.
  * ```ts
- * import { testRepository } from "@roka/github/testing";
+ * import { fakeRepository } from "@roka/github/testing";
  * import { assertEquals } from "@std/assert";
  *
- * const repo = testRepository();
- *
+ * const repo = fakeRepository();
  * const pull = await repo.pulls.create({ title: "title" });
  * assertEquals(await repo.pulls.list(), [pull]);
- *
  * const release = await repo.releases.create("tag");
  * assertEquals(await repo.releases.list(), [release]);
  * await release.delete();
  * assertEquals(await repo.releases.list(), []);
  * ```
  */
-export function testRepository(data?: Partial<Repository>): Repository {
+export function fakeRepository(data?: Partial<Repository>): Repository {
   let nextPull = 1;
   let nextRelease = 1;
   const pulls: PullRequest[] = [];
@@ -62,7 +56,7 @@ export function testRepository(data?: Partial<Repository>): Repository {
     pulls: {
       list: () => Promise.resolve(pulls),
       create: (options) => {
-        const pull = testPullRequest({
+        const pull = fakePullRequest({
           repo,
           number: nextPull++,
           ...options,
@@ -74,7 +68,7 @@ export function testRepository(data?: Partial<Repository>): Repository {
     releases: {
       list: () => Promise.resolve(releases),
       create: (tag, options) => {
-        const release = testRelease({
+        const release = fakeRelease({
           repo,
           tag,
           id: nextRelease++,
@@ -94,24 +88,23 @@ export function testRepository(data?: Partial<Repository>): Repository {
 }
 
 /**
- * Creates a pull request with fake data.
+ * Creates a pull request with fake data and operations.
  *
- * @example
+ * @example Create a pull request with a title.
  * ```ts
- * import { testPullRequest } from "@roka/github/testing";
+ * import { fakePullRequest } from "@roka/github/testing";
  * import { assertEquals } from "@std/assert";
  *
- * const pull = testPullRequest({ title: "title" });
+ * const pull = fakePullRequest({ title: "title" });
  * assertEquals(pull.title, "title");
- *
  * await pull.update({ title: "new title" });
  * assertEquals(pull.title, "new title");
  * ```
  */
 
-export function testPullRequest(data?: Partial<PullRequest>): PullRequest {
+export function fakePullRequest(data?: Partial<PullRequest>): PullRequest {
   const pull: PullRequest = {
-    repo: testRepository(),
+    repo: fakeRepository(),
     url: "url",
     number: 1,
     title: "title",
@@ -131,30 +124,28 @@ export function testPullRequest(data?: Partial<PullRequest>): PullRequest {
 }
 
 /**
- * Creates a release with fake data.
+ * Creates a release with fake data and operations.
  *
- * @example
+ * @example Create a release with a tag.
  * ```ts
- * import { testRelease } from "@roka/github/testing";
+ * import { fakeRelease } from "@roka/github/testing";
  * import { assertEquals } from "@std/assert";
  *
- * const release = testRelease({ tag: "tag" });
+ * const release = fakeRelease({ tag: "tag" });
  * assertEquals(release.tag, "tag");
- *
  * await release.update({ tag: "new tag" });
  * assertEquals(release.tag, "new tag");
- *
  * const asset = await release.assets.upload("file.txt");
  * assertEquals(await release.assets.list(), [asset]);
  * await asset.delete();
  * assertEquals(await release.assets.list(), []);
  * ```
  */
-export function testRelease(data?: Partial<Release>): Release {
+export function fakeRelease(data?: Partial<Release>): Release {
   let nextAsset = 1;
   const assets: ReleaseAsset[] = [];
   const release: Release = {
-    repo: testRepository(),
+    repo: fakeRepository(),
     url: "url",
     id: 1,
     name: "name",
@@ -171,7 +162,7 @@ export function testRelease(data?: Partial<Release>): Release {
     assets: {
       list: () => Promise.resolve(assets),
       upload: (file) => {
-        const asset = testReleaseAsset({
+        const asset = fakeReleaseAsset({
           release,
           name: basename(file),
           id: nextAsset++,
@@ -190,20 +181,20 @@ export function testRelease(data?: Partial<Release>): Release {
 }
 
 /**
- * Creates a release asset with fake data.
+ * Creates a release asset with fake data and operations.
  *
- * @example
+ * @example Create a release asset with a name.
  * ```ts
- * import { testReleaseAsset } from "@roka/github/testing";
+ * import { fakeReleaseAsset } from "@roka/github/testing";
  * import { assertEquals } from "@std/assert";
  *
- * const asset = testReleaseAsset({ name: "name" });
+ * const asset = fakeReleaseAsset({ name: "name" });
  * assertEquals(asset.name, "name");
  * ```
  */
-export function testReleaseAsset(data?: Partial<ReleaseAsset>): ReleaseAsset {
+export function fakeReleaseAsset(data?: Partial<ReleaseAsset>): ReleaseAsset {
   return {
-    release: testRelease(),
+    release: fakeRelease(),
     url: "url",
     id: 2,
     name: "name",

--- a/tool/forge/bump.test.ts
+++ b/tool/forge/bump.test.ts
@@ -2,7 +2,7 @@ import { pool } from "@roka/async/pool";
 import { bump } from "@roka/forge/bump";
 import { PackageError, packageInfo } from "@roka/forge/package";
 import { tempRepository } from "@roka/git/testing";
-import { testRepository } from "@roka/github/testing";
+import { fakeRepository } from "@roka/github/testing";
 import {
   assertEquals,
   assertExists,
@@ -78,7 +78,7 @@ Deno.test("bump() patch updates unreleased package", async () => {
 Deno.test("bump() creates pull request", async () => {
   await using remote = await tempRepository();
   await using git = await tempRepository({ clone: remote });
-  const repo = testRepository({ git });
+  const repo = fakeRepository({ git });
   const config = { name: "@scope/module", version: "0.0.0" };
   await Deno.writeTextFile(git.path("deno.json"), JSON.stringify(config));
   await git.index.add("deno.json");
@@ -104,7 +104,7 @@ Deno.test("bump() creates pull request", async () => {
 Deno.test("bump() updates pull request", async () => {
   await using remote = await tempRepository({ bare: true });
   await using git = await tempRepository({ clone: remote });
-  const repo = testRepository({ git });
+  const repo = fakeRepository({ git });
   const config = { name: "@scope/module", version: "0.0.0" };
   await Deno.writeTextFile(git.path("deno.json"), JSON.stringify(config));
   await git.index.add("deno.json");
@@ -130,7 +130,7 @@ Deno.test("bump() updates pull request", async () => {
 Deno.test("bump() updates multiple packages", async () => {
   await using remote = await tempRepository();
   await using git = await tempRepository({ clone: remote });
-  const repo = testRepository({ git });
+  const repo = fakeRepository({ git });
   const config1 = { name: "@scope/module1", version: "0.0.0" };
   const config2 = { name: "@scope/module2", version: "0.0.0" };
   await Deno.mkdir(git.path("module1"));

--- a/tool/forge/release.test.ts
+++ b/tool/forge/release.test.ts
@@ -1,7 +1,7 @@
 import { PackageError, packageInfo } from "@roka/forge/package";
 import { release } from "@roka/forge/release";
 import { tempRepository } from "@roka/git/testing";
-import { testRepository } from "@roka/github/testing";
+import { fakeRepository } from "@roka/github/testing";
 import { assertEquals, assertMatch, assertRejects } from "@std/assert";
 
 Deno.test("release() rejects package without version", async () => {
@@ -14,7 +14,7 @@ Deno.test("release() rejects package without version", async () => {
 
 Deno.test("release() creates initial release", async () => {
   await using git = await tempRepository();
-  const repo = testRepository({ git });
+  const repo = fakeRepository({ git });
   const config = { name: "@scope/module", version: "1.2.3" };
   await Deno.writeTextFile(git.path("deno.json"), JSON.stringify(config));
   await git.index.add("deno.json");
@@ -31,7 +31,7 @@ Deno.test("release() creates initial release", async () => {
 
 Deno.test("release() creates bump release", async () => {
   await using git = await tempRepository();
-  const repo = testRepository({ git });
+  const repo = fakeRepository({ git });
   const config = { name: "@scope/module", version: "1.2.3" };
   await Deno.writeTextFile(git.path("deno.json"), JSON.stringify(config));
   await git.index.add("deno.json");
@@ -50,7 +50,7 @@ Deno.test("release() creates bump release", async () => {
 
 Deno.test("release() creates draft release", async () => {
   await using git = await tempRepository();
-  const repo = testRepository({ git });
+  const repo = fakeRepository({ git });
   const config = { name: "@scope/module", version: "1.2.3" };
   await Deno.writeTextFile(git.path("deno.json"), JSON.stringify(config));
   await git.index.add("deno.json");
@@ -62,7 +62,7 @@ Deno.test("release() creates draft release", async () => {
 
 Deno.test("release() updates existing release", async () => {
   await using git = await tempRepository();
-  const repo = testRepository({ git });
+  const repo = fakeRepository({ git });
   const config = { name: "@scope/module", version: "1.2.3" };
   await Deno.writeTextFile(git.path("deno.json"), JSON.stringify(config));
   await git.index.add("deno.json");


### PR DESCRIPTION
Because they have fake behavior as well as fake data.