### PR TITLE
refactor(cli, github, testing): consistent object creation

### DIFF
--- a/core/cli/config.ts
+++ b/core/cli/config.ts
@@ -139,8 +139,6 @@ export function config<T extends Record<string, unknown>>(
     },
   };
   return Object.assign(config, {
-    [Symbol.dispose]() {
-      kv?.close();
-    },
+    [Symbol.dispose]: () => kv?.close(),
   });
 }

--- a/core/testing/mock.ts
+++ b/core/testing/mock.ts
@@ -349,9 +349,7 @@ export function mock<
           );
         }
       },
-      [Symbol.dispose]() {
-        mock.restore();
-      },
+      [Symbol.dispose]: () => mock.restore(),
     },
   );
   return Object.defineProperties(mock, {


### PR DESCRIPTION
- simplify [Symbol.dispose]
- don't use classes