### PR TITLE
docs: consistent error constructor documentation

### DIFF
--- a/core/git/git.ts
+++ b/core/git/git.ts
@@ -57,11 +57,7 @@ import { basename, join } from "@std/path";
  * command and its output.
  */
 export class GitError extends Error {
-  /**
-   * Construct GitError.
-   *
-   * @param message The error message to be associated with this error.
-   */
+  /** Construct GitError. */
   constructor(message: string) {
     super(message);
     this.name = "GitError";

--- a/core/http/request.ts
+++ b/core/http/request.ts
@@ -75,13 +75,7 @@ export class RequestError extends Error {
   /** The status code of the response. */
   readonly status?: number;
 
-  /**
-   * Construct RequestError.
-   *
-   * @param message The error message to be associated with this error.
-   * @param status The status code of the response.
-   * @param cause The cause of the error.
-   */
+  /** Construct RequestError. */
   constructor(
     message: string,
     options?: { status?: number; cause?: unknown },

--- a/tool/forge/package.ts
+++ b/tool/forge/package.ts
@@ -52,12 +52,7 @@ import {
 
 /** An error thrown by the {@link [jsr:@roka/forge]} module. */
 export class PackageError extends Error {
-  /**
-   * Construct PackageError.
-   *
-   * @param message The error message to be associated with this error.
-   * @param options.cause The cause of the error.
-   */
+  /** Construct PackageError. */
   constructor(message: string, options?: { cause?: unknown }) {
     super(message, options);
     this.name = "PackageError";


### PR DESCRIPTION
Removing constructor param docs because deno doc does not generate them. Some of there were wrong to begin with.