### PR TITLE
chore: remove the `example` package

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,9 +1,6 @@
 core:
   - changed-files:
       - any-glob-to-any-file: core/**
-example:
-  - changed-files:
-      - any-glob-to-any-file: app/example/**
 forge:
   - changed-files:
       - any-glob-to-any-file: tool/forge/**

--- a/app/example/deno.json
+++ b/app/example/deno.json
@@ -1,5 +1,0 @@
-{
-  "compile": {
-    "main": "example.ts"
-  }
-}

--- a/app/example/example.ts
+++ b/app/example/example.ts
@@ -1,6 +1,0 @@
-// deno-lint-ignore-file no-console
-import { version } from "@roka/forge/version";
-
-if (import.meta.main) {
-  console.log(`Hello, world! [version: ${await version()}]`);
-}

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,5 @@
 {
   "workspace": [
-    "./app/example",
     "./core/async",
     "./core/cli",
     "./core/git",


### PR DESCRIPTION
Unit tests now cover what this was used for (package with no version).