### PR TITLE
fix(forge): `version()` returns single line string

### DIFF
--- a/tool/forge/forge.ts
+++ b/tool/forge/forge.ts
@@ -207,7 +207,7 @@
  * forge --version
  * ```
  * ```
- * forge 0.1.0 (aarch64-apple-darwin)
+ * forge 0.1.0 (release, aarch64-apple-darwin)
  * deno 2.2.3
  * v8 13.4.114.11-rusty
  * typescript 5.7.3
@@ -283,7 +283,10 @@ export async function forge(
   let verbose = false;
   const cmd = new Command()
     .name("forge")
-    .version(await version({ build: true, deno: true }))
+    .version(await version({ release: true, target: true }))
+    .meta("deno", Deno.version.deno)
+    .meta("v8", Deno.version.v8)
+    .meta("typescript", Deno.version.typescript)
     .description(DESCRIPTION)
     .example("forge", "List all packages.")
     .example("forge list 'core/*'", "List packages in the 'core' directory.")

--- a/tool/forge/version.test.ts
+++ b/tool/forge/version.test.ts
@@ -1,17 +1,14 @@
 import { version } from "@roka/forge/version";
-import { assertMatch } from "@std/assert";
+import { assertMatch, assertStringIncludes } from "@std/assert";
 
 Deno.test("version() provides version", async () => {
   assertMatch(await version(), /[^\s]+/);
 });
 
-Deno.test("version({ build: true }) includes build target", async () => {
-  assertMatch(await version({ build: true }), /[^\s]+ \([^\s]+\)/);
+Deno.test("version({ release: true }) includes release type", async () => {
+  assertMatch(await version({ release: true }), /[^\s]+ \([^\s]+\)/);
 });
 
-Deno.test("version({ deno: true }) lists deno versions as lines", async () => {
-  assertMatch(
-    await version({ deno: true }),
-    /[^\s]+\ndeno [^\s]+\nv8 [^\s]+\ntypescript [^\s]+/,
-  );
+Deno.test("version({ target: true }) includes target architecture", async () => {
+  assertStringIncludes(await version({ target: true }), Deno.build.target);
 });


### PR DESCRIPTION
Dropping versions from deno, v8 and typescript. These will be added as a meta to the CLI help.

Adding "release", "pre-release" identifier.