### PR TITLE
chore: bump forge to 0.1.1-pre.3+ef268ea

### DIFF
--- a/tool/forge/deno.json
+++ b/tool/forge/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@roka/forge",
-  "version": "0.1.0",
+  "version": "0.1.1-pre.3+ef268ea",
   "exports": {
     ".": "./forge.ts",
     "./bump": "./bump.ts",


### PR DESCRIPTION
## forge@0.1.1-pre.3+ef268ea

- 🐛 mention version number in title if bumping a single package
- 🐛 use full commit summaries in bump commits
- 🐛 #193
