### PR TITLE
fix(forge): add commit hash when there is no pull request number

### DIFF
--- a/tool/forge/bump.test.ts
+++ b/tool/forge/bump.test.ts
@@ -200,6 +200,7 @@ Deno.test("bump() creates a pull request", async () => {
     ],
   });
   const repo = fakeRepository({ git: git({ cwd: pkg.root }) });
+  const short = (await repo.git.commits.head())?.short;
   const current = await repo.git.branches.current();
   const pr = await bump([pkg], {
     release: true,
@@ -218,7 +219,7 @@ Deno.test("bump() creates a pull request", async () => {
     [
       "## name@1.3.0",
       "",
-      "- fix: force pushed",
+      `- fix: force pushed (${short})`,
       "- #42",
       "",
     ].join("\n"),
@@ -236,7 +237,7 @@ Deno.test("bump() creates a pull request", async () => {
     [
       "## name@1.3.0",
       "",
-      "- fix: force pushed",
+      `- fix: force pushed (${short})`,
       "- feat: new feature (#42)",
     ].join("\n"),
   );

--- a/tool/forge/bump.ts
+++ b/tool/forge/bump.ts
@@ -181,6 +181,7 @@ async function createPullRequest(
     changelog(pkg.changes ?? [], {
       title: `${pkg.name}@${pkg.version}`,
       emoji: options?.emoji ?? false,
+      hash: true,
     })
   ).join("\n");
   const prBody = packages.map((pkg) =>
@@ -188,6 +189,7 @@ async function createPullRequest(
       title: `${pkg.name}@${pkg.version}`,
       github: true,
       emoji: options?.emoji ?? false,
+      hash: true,
     })
   ).join("\n");
   try {

--- a/tool/forge/changelog.test.ts
+++ b/tool/forge/changelog.test.ts
@@ -111,6 +111,23 @@ Deno.test("changelog() generates frivolous changelog with emojis", () => {
   );
 });
 
+Deno.test("changelog() generates commit hashes", () => {
+  const commits = [
+    testCommit({ summary: "fix code (#1)" }),
+    testCommit({ summary: "not a number (#this is not)", short: "short-1" }),
+    testCommit({ summary: "no number", short: "short-2" }),
+  ];
+  assertEquals(
+    changelog(commits, { hash: true }),
+    [
+      "- fix code (#1)",
+      "- not a number (#this is not) (short-1)",
+      "- no number (short-2)",
+      "",
+    ].join("\n"),
+  );
+});
+
 Deno.test("changelog() generates pull request numbers", () => {
   const commits = [
     testCommit({ summary: "feat(name): introduce (#3)" }),

--- a/tool/forge/changelog.ts
+++ b/tool/forge/changelog.ts
@@ -51,8 +51,21 @@ export interface ChangelogOptions {
      */
     bullet?: string;
   };
-  /** Use emoji in commit summaries. */
+  /**
+   * Use emoji in commit summaries.
+   * @default {false}
+   */
   emoji?: boolean;
+  /**
+   * Include short commit short in commit summaries, when a pull request number
+   * is not available.
+   *
+   * This is useful for generating links to commits that were not merged with a
+   * pull request.
+   *
+   * @default {false}
+   */
+  hash?: boolean;
   /**
    * List only pull request numbers as commit summaries.
    *
@@ -61,6 +74,8 @@ export interface ChangelogOptions {
    *
    * Changelogs for releases and markdown files should not use this option,
    * because GitHub does not provide the pull request title in those contexts.
+   *
+   * @default {false}
    */
   github?: boolean;
 }
@@ -120,11 +135,14 @@ function summary(
   commit: ConventionalCommit,
   options: ChangelogOptions | undefined,
 ): string {
-  const summary = options?.emoji ? commit.description : commit.summary;
-  const result = options?.github
-    ? summary.replace(/^.*\((#\d+)\)$/, "$1")
-    : summary;
-  return options?.emoji ? emoji(commit, result) : result;
+  const prPattern = /^.*\((#\d+)\)$/;
+  let summary = options?.emoji ? commit.description : commit.summary;
+  if (options?.hash && !summary.match(prPattern)) {
+    summary = `${summary} (${commit.short})`;
+  }
+  if (options?.github) summary = summary.replace(prPattern, "$1");
+  if (options?.emoji) summary = emoji(commit, summary);
+  return summary;
 }
 
 function emoji(commit: ConventionalCommit, summary: string): string {

--- a/tool/forge/release.test.ts
+++ b/tool/forge/release.test.ts
@@ -45,7 +45,7 @@ Deno.test("release() rejects 0.0.0", async () => {
 Deno.test("release() creates initial release", async () => {
   await using pkg = await tempPackage({
     config: { name: "@scope/name", version: "0.1.0" },
-    commits: [{ summary: "feat: new feature" }],
+    commits: [{ summary: "feat: new feature (#1)" }],
   });
   const repo = fakeRepository({ url: "url", git: git({ cwd: pkg.root }) });
   const [rls, assets] = await release(pkg, { repo });
@@ -56,7 +56,7 @@ Deno.test("release() creates initial release", async () => {
     [
       "## Initial release",
       "",
-      "feat: new feature",
+      "feat: new feature (#1)",
       "",
       "### Details",
       "",
@@ -75,7 +75,7 @@ Deno.test("release() creates update release", async () => {
     config: { name: "@scope/name", version: "1.3.0" },
     commits: [
       { summary: "initial", tags: ["name@1.2.3"] },
-      { summary: "feat: new feature" },
+      { summary: "feat: new feature (#1)" },
     ],
   });
   const repo = fakeRepository({ url: "url", git: git({ cwd: pkg.root }) });
@@ -87,7 +87,7 @@ Deno.test("release() creates update release", async () => {
     [
       "## Changes",
       "",
-      "feat: new feature",
+      "feat: new feature (#1)",
       "",
       "### Details",
       "",
@@ -131,7 +131,7 @@ Deno.test("release() updates existing release", async () => {
     config: { name: "@scope/name", version: `1.3.0` },
     commits: [
       { summary: "initial", tags: ["name@1.2.3"] },
-      { summary: "feat: new feature" },
+      { summary: "feat: new feature (#1)" },
     ],
   });
   const repo = fakeRepository({ url: "url", git: git({ cwd: pkg.root }) });
@@ -144,7 +144,7 @@ Deno.test("release() updates existing release", async () => {
     [
       "## Changes",
       "",
-      "feat: new feature",
+      "feat: new feature (#1)",
       "",
       "### Details",
       "",

--- a/tool/forge/release.ts
+++ b/tool/forge/release.ts
@@ -149,5 +149,6 @@ function body(
     markdown: {
       bullet: "",
     },
+    hash: true,
   });
 }


### PR DESCRIPTION
…PR number

This creates a clickable link to the commit.