### PR TITLE
fix(git): skip ignored files by default in `git().index.status()`

### DIFF
--- a/core/git/git.test.ts
+++ b/core/git/git.test.ts
@@ -718,7 +718,7 @@ Deno.test("git().index.status() can list files under untracked directories", asy
   });
 });
 
-Deno.test("git().index.status() lists ignored files", async () => {
+Deno.test("git().index.status() skips ignored files", async () => {
   await using repo = await tempRepository();
   await Deno.writeTextFile(repo.path(".gitignore"), "file");
   await repo.index.add(".gitignore");
@@ -728,21 +728,21 @@ Deno.test("git().index.status() lists ignored files", async () => {
     staged: [],
     unstaged: [],
     untracked: [],
-    ignored: [{ path: "file" }],
+    ignored: [],
   });
 });
 
-Deno.test("git().index.status() can skip ignored files", async () => {
+Deno.test("git().index.status() can list ignored files", async () => {
   await using repo = await tempRepository();
   await Deno.writeTextFile(repo.path(".gitignore"), "file");
   await repo.index.add(".gitignore");
   await repo.commits.create("commit");
   await Deno.writeTextFile(repo.path("file"), "content");
-  assertEquals(await repo.index.status({ ignored: false }), {
+  assertEquals(await repo.index.status({ ignored: true }), {
     staged: [],
     unstaged: [],
     untracked: [],
-    ignored: [],
+    ignored: [{ path: "file" }],
   });
 });
 
@@ -842,7 +842,7 @@ Deno.test("git().index.status() can list staged and ignored changes to the same 
   await repo.commits.create("commit");
   await repo.index.remove("file");
   await Deno.writeTextFile(repo.path("file"), "content");
-  assertEquals(await repo.index.status(), {
+  assertEquals(await repo.index.status({ ignored: true }), {
     staged: [{ path: "file", status: "deleted" }],
     unstaged: [],
     untracked: [],

--- a/core/git/git.ts
+++ b/core/git/git.ts
@@ -482,7 +482,7 @@ export interface IndexStatusOptions {
    * {@linkcode IndexStatusOptions.untracked | untracked} is set to `"all"`. If
    * set to `false`, ignored files are not included.
    *
-   * @default {true}
+   * @default {false}
    */
   ignored?: boolean;
   /**
@@ -812,7 +812,7 @@ export function git(options?: GitOptions): Git {
         await run(gitOptions, "rm", options?.force && "--force", path);
       },
       async status(options?: IndexStatusOptions) {
-        const { path, untracked = true, ignored = true, renames = true } =
+        const { path, untracked = true, ignored = false, renames = true } =
           options ?? {};
         const output = await run(
           gitOptions,


### PR DESCRIPTION
This is more performant and it matches the behavior of the git command-line.