### PR TITLE
ci: run ci at deno 2.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Setup
         uses: denoland/setup-deno@v2
+        with:
+          deno-version: "2.4.5"
 
       - name: Test
         run: deno task test --coverage


### PR DESCRIPTION
Temporary measure. 2.5 is breaking some tests.