### PR TITLE
fix(async/pool): remove pool of async generators

### DIFF
--- a/core/async/deno.json
+++ b/core/async/deno.json
@@ -5,5 +5,11 @@
     ".": "./async.ts",
     "./any": "./any.ts",
     "./pool": "./pool.ts"
+  },
+  "test": {
+    "permissions": {
+      "read": true,
+      "env": true
+    }
   }
 }

--- a/core/async/pool.test.ts
+++ b/core/async/pool.test.ts
@@ -64,17 +64,7 @@ Deno.test("pool() handles iterable map", async () => {
   assertEquals(results, [1, 2, 3]);
 });
 
-Deno.test("pool() handles async iterable of promises", async () => {
-  async function* asyncGenerator() {
-    yield Promise.resolve(1);
-    yield Promise.resolve(2);
-    yield Promise.resolve(3);
-  }
-  const results = await pool(asyncGenerator());
-  assertEquals(results, [1, 2, 3]);
-});
-
-Deno.test("pool() handles async iterable to promises map", async () => {
+Deno.test("pool() handles async iterable map", async () => {
   async function* asyncGenerator() {
     yield 1;
     yield 2;
@@ -84,7 +74,7 @@ Deno.test("pool() handles async iterable to promises map", async () => {
   assertEquals(results, [1, 2, 3]);
 });
 
-Deno.test("pool() handles async iterable to promises map", async () => {
+Deno.test("pool() handles async iterable of promises map", async () => {
   async function* asyncGenerator() {
     yield Promise.resolve(1);
     yield Promise.resolve(2);
@@ -178,29 +168,7 @@ Deno.test("pooled() handles iterable map", async () => {
   assertEquals(results, [1, 2, 3]);
 });
 
-Deno.test("pooled() handles async iterable", async () => {
-  async function* asyncGenerator() {
-    yield Promise.resolve(1);
-    yield Promise.resolve(2);
-    yield Promise.resolve(3);
-  }
-  const results = await Array.fromAsync(pooled(asyncGenerator()));
-  assertEquals(results, [1, 2, 3]);
-});
-
 Deno.test("pooled() handles async iterable map", async () => {
-  async function* asyncGenerator() {
-    yield Promise.resolve(1);
-    yield Promise.resolve(2);
-    yield Promise.resolve(3);
-  }
-  const results = await Array.fromAsync(
-    pooled(asyncGenerator()),
-  );
-  assertEquals(results, [1, 2, 3]);
-});
-
-Deno.test("pooled() handles async iterable to promises map", async () => {
   async function* asyncGenerator() {
     yield Promise.resolve(1);
     yield Promise.resolve(2);

--- a/core/async/pool.ts
+++ b/core/async/pool.ts
@@ -108,7 +108,7 @@ export interface PoolOptions {
  * @returns A promise that resolves all inputs concurrently.
  */
 export async function pool<T>(
-  array: Iterable<() => Promise<T>> | AsyncIterable<T>,
+  array: Iterable<() => Promise<T>>,
   options?: PoolOptions,
 ): Promise<T[]>;
 
@@ -180,9 +180,7 @@ export async function pool<T, R>(
 ): Promise<(T | R)[]> {
   if (typeof iteratorFnOrOptions !== "function") {
     return await Array.fromAsync(
-      Symbol.asyncIterator in array
-        ? pooled(array, iteratorFnOrOptions)
-        : pooled(array as Iterable<() => Promise<T>>, options),
+      pooled(array as Iterable<() => Promise<T>>, options),
     );
   }
   return await Array.fromAsync(pooled(
@@ -259,7 +257,7 @@ export async function pool<T, R>(
  * @returns An async iterator for the resolved promises.
  */
 export function pooled<T>(
-  array: Iterable<() => Promise<T>> | AsyncIterable<T>,
+  array: Iterable<() => Promise<T>>,
   options?: PoolOptions,
 ): AsyncIterableIterator<T>;
 
@@ -342,13 +340,11 @@ export function pooled<T, R>(
   options?: PoolOptions,
 ): AsyncIterableIterator<T | R> {
   if (typeof iteratorFnOrOptions !== "function") {
-    return Symbol.asyncIterator in array
-      ? pooled(array, (x) => Promise.resolve(x), iteratorFnOrOptions)
-      : pooled(
-        array as Iterable<() => Promise<T>>,
-        (x) => x(),
-        iteratorFnOrOptions,
-      );
+    return pooled(
+      array as Iterable<() => Promise<T>>,
+      (x) => x(),
+      iteratorFnOrOptions,
+    );
   }
   const { concurrency = Infinity } = options ?? {};
   return pooledMap(


### PR DESCRIPTION
These were just `Array.fromAsync`, with no actual concurrency.