### PR TITLE
chore: refine dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,6 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "quarterly"
+      interval: "monthly"
     commit-message:
-      prefix: "ci"
+      prefix: "chore"


### PR DESCRIPTION
1. Monthly updates for actions, since immutable actions are now a thing.
2. `chore` type since this is still a dependency update.