### PR TITLE
refactor(async/pool): rename `asyncGenerator` to `asyncIterable`

### DIFF
--- a/core/async/pool.test.ts
+++ b/core/async/pool.test.ts
@@ -65,22 +65,22 @@ Deno.test("pool() handles iterable map", async () => {
 });
 
 Deno.test("pool() handles async iterable map", async () => {
-  async function* asyncGenerator() {
+  async function* asyncIterable() {
     yield 1;
     yield 2;
     yield 3;
   }
-  const results = await pool(asyncGenerator(), (x) => Promise.resolve(x));
+  const results = await pool(asyncIterable(), (x) => Promise.resolve(x));
   assertEquals(results, [1, 2, 3]);
 });
 
 Deno.test("pool() handles async iterable of promises map", async () => {
-  async function* asyncGenerator() {
+  async function* asyncIterable() {
     yield Promise.resolve(1);
     yield Promise.resolve(2);
     yield Promise.resolve(3);
   }
-  const results = await pool(asyncGenerator(), (x) => Promise.resolve(x));
+  const results = await pool(asyncIterable(), (x) => Promise.resolve(x));
   assertEquals(results, [1, 2, 3]);
 });
 
@@ -169,13 +169,13 @@ Deno.test("pooled() handles iterable map", async () => {
 });
 
 Deno.test("pooled() handles async iterable map", async () => {
-  async function* asyncGenerator() {
+  async function* asyncIterable() {
     yield Promise.resolve(1);
     yield Promise.resolve(2);
     yield Promise.resolve(3);
   }
   const results = await Array.fromAsync(
-    pooled(asyncGenerator(), (x) => Promise.resolve(x)),
+    pooled(asyncIterable(), (x) => Promise.resolve(x)),
   );
   assertEquals(results, [1, 2, 3]);
 });

--- a/core/async/pool.ts
+++ b/core/async/pool.ts
@@ -133,13 +133,13 @@ export async function pool<T>(
  * import { pool } from "@roka/async/pool";
  * import { assertEquals } from "jsr:@std/assert";
  *
- * async function* asyncGenerator() {
+ * async function* asyncIterable() {
  *   yield 1;
  *   yield 2;
  *   yield 3;
  * }
  * const results = await pool(
- *   asyncGenerator(),
+ *   asyncIterable(),
  *   (value) => Promise.resolve(value * 2),
  * );
  *
@@ -225,12 +225,12 @@ export async function pool<T, R>(
  * import { assertEquals } from "jsr:@std/assert";
  *
  * const results: number[] = [];
- * async function* asyncGenerator() {
+ * async function* asyncIterable() {
  *   yield 1;
  *   yield 2;
  *   yield 3;
  * }
- * for await (const number of pooled(asyncGenerator())) {
+ * for await (const number of pooled(asyncIterable())) {
  *   results.push(number);
  * }
  *
@@ -292,13 +292,13 @@ export function pooled<T>(
  * import { assertEquals } from "jsr:@std/assert";
  *
  * const results: number[] = [];
- * async function* asyncGenerator() {
+ * async function* asyncIterable() {
  *   yield 1;
  *   yield 2;
  *   yield 3;
  * }
  * for await (const number of pooled(
- *   asyncGenerator(),
+ *   asyncIterable(),
  *   (value) => Promise.resolve(value * 2),
  * )) {
  *   results.push(number);


### PR DESCRIPTION
Tests are not using anything from the generator interface.