### PR TITLE
docs(forge): mark forge modules as internal

### DIFF
--- a/tool/forge/bump.ts
+++ b/tool/forge/bump.ts
@@ -26,6 +26,7 @@
  * @todo Check if configuration files are dirty before modifying them.
  *
  * @module bump
+ * @internal
  */
 
 import { pool } from "@roka/async/pool";

--- a/tool/forge/changelog.ts
+++ b/tool/forge/changelog.ts
@@ -13,6 +13,7 @@
  * ```
  *
  * @module changelog
+ * @internal
  */
 
 import type { Commit } from "@roka/git";

--- a/tool/forge/compile.ts
+++ b/tool/forge/compile.ts
@@ -26,6 +26,7 @@
  * ```
  *
  * @module compile
+ * @internal
  */
 
 import { pool } from "@roka/async/pool";

--- a/tool/forge/package.ts
+++ b/tool/forge/package.ts
@@ -43,6 +43,7 @@
  * package.
  *
  * @module package
+ * @internal
  */
 
 import { pool } from "@roka/async/pool";

--- a/tool/forge/release.ts
+++ b/tool/forge/release.ts
@@ -18,6 +18,7 @@
  * ```
  *
  * @module release
+ * @internal
  */
 
 import { pool } from "@roka/async/pool";

--- a/tool/forge/testing.ts
+++ b/tool/forge/testing.ts
@@ -19,6 +19,7 @@
  * ```
  *
  * @module testing
+ * @internal
  */
 
 import { tempRepository, type TempRepositoryOptions } from "@roka/git/testing";


### PR DESCRIPTION
So they are not subject to stringent documentation lint.