### PR TITLE
docs(http): rename `mockFetch` examples to `"mockFetch() example"`

### DIFF
--- a/core/http/__mocks__/testing.ts.mock
+++ b/core/http/__mocks__/testing.ts.mock
@@ -1,6 +1,6 @@
 export const mock = {};
 
-mock[`mockFetch() > fetch 1`] =
+mock[`mockFetch() example > fetch 1`] =
 [
   {
     input: [
@@ -11,52 +11,7 @@ mock[`mockFetch() > fetch 1`] =
       },
     ],
     output: [
-      "<!doctype html>\n" +
-        "<html>\n" +
-        "<head>\n" +
-        "    <title>Example Domain</title>\n" +
-        "\n" +
-        '    <meta charset="utf-8" />\n' +
-        '    <meta http-equiv="Content-type" content="text/html; charset=utf-8" />\n' +
-        '    <meta name="viewport" content="width=device-width, initial-scale=1" />\n' +
-        '    <style type="text/css">\n' +
-        "    body {\n" +
-        "        background-color: #f0f0f2;\n" +
-        "        margin: 0;\n" +
-        "        padding: 0;\n" +
-        '        font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;\n' +
-        "        \n" +
-        "    }\n" +
-        "    div {\n" +
-        "        width: 600px;\n" +
-        "        margin: 5em auto;\n" +
-        "        padding: 2em;\n" +
-        "        background-color: #fdfdff;\n" +
-        "        border-radius: 0.5em;\n" +
-        "        box-shadow: 2px 3px 7px 2px rgba(0,0,0,0.02);\n" +
-        "    }\n" +
-        "    a:link, a:visited {\n" +
-        "        color: #38488f;\n" +
-        "        text-decoration: none;\n" +
-        "    }\n" +
-        "    @media (max-width: 700px) {\n" +
-        "        div {\n" +
-        "            margin: 0 auto;\n" +
-        "            width: auto;\n" +
-        "        }\n" +
-        "    }\n" +
-        "    </style>    \n" +
-        "</head>\n" +
-        "\n" +
-        "<body>\n" +
-        "<div>\n" +
-        "    <h1>Example Domain</h1>\n" +
-        "    <p>This domain is for use in illustrative examples in documents. You may use this\n" +
-        "    domain in literature without prior coordination or asking for permission.</p>\n" +
-        '    <p><a href="https://www.iana.org/domains/example">More information...</a></p>\n' +
-        "</div>\n" +
-        "</body>\n" +
-        "</html>\n",
+      '<!doctype html><html lang="en"><head><title>Example Domain</title><meta name="viewport" content="width=device-width, initial-scale=1"><style>body{background:#eee;width:60vw;margin:15vh auto;font-family:system-ui,sans-serif}h1{font-size:1.5em}div{opacity:0.8}a:link,a:visited{color:#348}</style><body><div><h1>Example Domain</h1><p>This domain is for use in documentation examples without needing permission. Avoid use in operations.<p><a href="https://iana.org/domains/example">Learn more</a></div></body></html>\n',
       {
         headers: {
           "Content-Type": "text/html",

--- a/core/http/testing.ts
+++ b/core/http/testing.ts
@@ -5,7 +5,7 @@
  *
  * ```ts
  * import { mockFetch } from "@roka/http/testing";
- * Deno.test("mockFetch()", async (t) => {
+ * Deno.test("mockFetch() example", async (t) => {
  *   using fetch = mockFetch(t, {
  *     path: "__mocks__/testing.ts.mock",
  *     ignore: { headers: true },
@@ -67,7 +67,7 @@ export interface MockFetchOptions extends MockOptions {
  * import { mockFetch } from "@roka/http/testing";
  * import { assertEquals } from "@std/assert";
  *
- * Deno.test("mockFetch()", async (t) => {
+ * Deno.test("mockFetch() example", async (t) => {
  *   using fetch = mockFetch(t, {
  *     path: "__mocks__/testing.ts.mock",
  *     ignore: { headers: true },


### PR DESCRIPTION
These are in JSDoc of core/http/testing.ts. The test name shows up in testing contexts. It makes sense to rename these test to something more readable.