### PR TITLE
feat(testing/fake): negate color and ansi stripping options in `fakeConsole()`

### DIFF
--- a/core/testing/fake.test.ts
+++ b/core/testing/fake.test.ts
@@ -204,31 +204,28 @@ Deno.test("fakeConsole().output() can wrap output", () => {
   assertEquals(console.output({ wrap: "'" }), "'first\nsecond'");
 });
 
-Deno.test("fakeConsole().output() ignores ANSI escape codes by default", () => {
+Deno.test("fakeConsole().output() captures ANSI escape codes by default", () => {
   using console = fakeConsole();
   console.log("\u001b[31mred\u001b[0m");
-  assertEquals(console.output(), "red");
+  assertEquals(console.output(), "\u001b[31mred\u001b[0m");
 });
 
-Deno.test("fakeConsole().output() can capture ANSI escape codes", () => {
+Deno.test("fakeConsole().output() can strip ANSI escape codes", () => {
   using console = fakeConsole();
   console.log("\u001b[31mred\u001b[0m");
-  assertEquals(console.output({ ansi: true }), "\u001b[31mred\u001b[0m");
+  assertEquals(console.output({ stripAnsi: true }), "red");
 });
 
-Deno.test("fakeConsole().output() ignores styling by default", () => {
+Deno.test("fakeConsole().output() captures CSS styling by default", () => {
   using console = fakeConsole();
   console.log("%clog", "color: red", "font-weight: bold");
-  assertEquals(console.output(), "log");
+  assertEquals(console.output(), "%clog color: red font-weight: bold");
 });
 
-Deno.test("fakeConsole().output() can capture styling", () => {
+Deno.test("fakeConsole().output() can strip CSS styling", () => {
   using console = fakeConsole();
   console.log("%clog", "color: red", "font-weight: bold");
-  assertEquals(
-    console.output({ color: true }),
-    "%clog color: red font-weight: bold",
-  );
+  assertEquals(console.output({ stripCss: true }), "log");
 });
 
 Deno.test("fakeCommand() stubs Deno.Command", async () => {

--- a/tool/forge/forge.test.ts
+++ b/tool/forge/forge.test.ts
@@ -82,7 +82,7 @@ async function run(context: Deno.TestContext) {
     await forge({ repo });
     // deno-lint-ignore no-console
     return console
-      .output({ trimEnd: true, wrap: "\n" })
+      .output({ stripCss: true, stripAnsi: true, trimEnd: true, wrap: "\n" })
       .replace(/(?<=\n)((?:.*?):\s*)\d+(\.\d+)+(?:.*)?/g, "$1<version>")
       .replace(/(?<=(\d+\.\d+\.\d+-\w+\.\d+)\+)(.......)/g, "<hash>")
       .replaceAll(root, "<directory>");


### PR DESCRIPTION
Making `output()` return everything logged by the default, for the least amount of surprise in behavior. This also makes css and ansi stripping a verbose choice in tests, improving readability.