### PR TITLE
style(testing/fake): order `fakeConsole()` options alphabetically

### DIFF
--- a/core/testing/fake.test.ts
+++ b/core/testing/fake.test.ts
@@ -187,23 +187,6 @@ Deno.test("fakeConsole().output() can filter by level", () => {
   assertEquals(console.output({ level: "error" }), "");
 });
 
-Deno.test("fakeConsole().output() can trim line ends", () => {
-  using console = fakeConsole();
-  console.info("first ");
-  console.debug("second  \n ");
-  console.log();
-  assertEquals(console.output({ trimEnd: false }), "first \nsecond  \n \n");
-  assertEquals(console.output({ trimEnd: true }), "first\nsecond\n\n");
-});
-
-Deno.test("fakeConsole().output() can wrap output", () => {
-  using console = fakeConsole();
-  console.info("first");
-  console.debug("second");
-  assertEquals(console.output({ wrap: "\n" }), "\nfirst\nsecond\n");
-  assertEquals(console.output({ wrap: "'" }), "'first\nsecond'");
-});
-
 Deno.test("fakeConsole().output() captures ANSI escape codes by default", () => {
   using console = fakeConsole();
   console.log("\u001b[31mred\u001b[0m");
@@ -226,6 +209,23 @@ Deno.test("fakeConsole().output() can strip CSS styling", () => {
   using console = fakeConsole();
   console.log("%clog", "color: red", "font-weight: bold");
   assertEquals(console.output({ stripCss: true }), "log");
+});
+
+Deno.test("fakeConsole().output() can trim line ends", () => {
+  using console = fakeConsole();
+  console.info("first ");
+  console.debug("second  \n ");
+  console.log();
+  assertEquals(console.output({ trimEnd: false }), "first \nsecond  \n \n");
+  assertEquals(console.output({ trimEnd: true }), "first\nsecond\n\n");
+});
+
+Deno.test("fakeConsole().output() can wrap output", () => {
+  using console = fakeConsole();
+  console.info("first");
+  console.debug("second");
+  assertEquals(console.output({ wrap: "\n" }), "\nfirst\nsecond\n");
+  assertEquals(console.output({ wrap: "'" }), "'first\nsecond'");
 });
 
 Deno.test("fakeCommand() stubs Deno.Command", async () => {

--- a/core/testing/fake.ts
+++ b/core/testing/fake.ts
@@ -219,13 +219,6 @@ export interface FakeConsoleOutputOptions {
   /** Filter for the log level of output. */
   level?: "debug" | "log" | "info" | "warn" | "error";
   /**
-   * Trim horizontal whitespace from output lines.
-   * @default {false}
-   */
-  trimEnd?: boolean;
-  /** Wrap output with a string on both sides before returning it. */
-  wrap?: string;
-  /**
    * Strip ANSI escape codes from output.
    *
    * @see {@link https://en.wikipedia.org/wiki/ANSI_escape_code ANSI escape code}
@@ -241,6 +234,13 @@ export interface FakeConsoleOutputOptions {
    * @default {false}
    */
   stripCss?: boolean;
+  /**
+   * Trim horizontal whitespace from output lines.
+   * @default {false}
+   */
+  trimEnd?: boolean;
+  /** Wrap output with a string on both sides before returning it. */
+  wrap?: string;
 }
 
 /**

--- a/tool/forge/forge.test.ts
+++ b/tool/forge/forge.test.ts
@@ -82,7 +82,7 @@ async function run(context: Deno.TestContext) {
     await forge({ repo });
     // deno-lint-ignore no-console
     return console
-      .output({ stripCss: true, stripAnsi: true, trimEnd: true, wrap: "\n" })
+      .output({ stripAnsi: true, stripCss: true, trimEnd: true, wrap: "\n" })
       .replace(/(?<=\n)((?:.*?):\s*)\d+(\.\d+)+(?:.*)?/g, "$1<version>")
       .replace(/(?<=(\d+\.\d+\.\d+-\w+\.\d+)\+)(.......)/g, "<hash>")
       .replaceAll(root, "<directory>");


### PR DESCRIPTION
Level is still at the top as primary option

For the rest, alphabetical and logical ordering is the same, so I couldn't miss this opportunity.