### PR TITLE
docs: make examples pass type-checks in isolation

### DIFF
--- a/core/assert/assert.ts
+++ b/core/assert/assert.ts
@@ -3,10 +3,12 @@
  * {@link https://jsr.io/@std/assert | **@std/assert**} library.
  *
  * ```ts
+ * import { assertSameElements } from "@roka/assert";
  * assertSameElements(["Alice", "Bob"], ["Bob", "Alice"]);
  * ```
  *
  * ```ts
+ * import { assertArrayObjectMatch } from "@roka/assert";
  * assertArrayObjectMatch(
  *   [{ id: 1, name: "Alice" }, { id: 2, name: "Bob" }],
  *   [{ name: "Alice" }, { name: "Bob" }],

--- a/tool/forge/changelog.ts
+++ b/tool/forge/changelog.ts
@@ -4,6 +4,7 @@
  * {@link https://www.conventionalcommits.org | Conventional Commits}.
  *
  * ```ts
+ * import { changelog } from "@roka/forge/changelog";
  * import { packageInfo } from "@roka/forge/package";
  * (async () => {
  *   const pkg = await packageInfo();

--- a/tool/forge/package.ts
+++ b/tool/forge/package.ts
@@ -30,6 +30,7 @@
  * in a monorepo.
  *
  * ```ts
+ * import { workspace } from "@roka/forge/package";
  * (async () => {
  *   const packages = await workspace();
  *   return { packages };

--- a/tool/forge/version.ts
+++ b/tool/forge/version.ts
@@ -53,12 +53,14 @@ export interface VersionOptions {
  *
  * @example Retrieve the version of the current package.
  * ```ts
+ * import { version } from "@roka/forge/version";
  * await version();
  * // 1.0.0
  * ```
  *
  * @example Retrieve the version with meta information.
  * ```ts
+ * import { version } from "@roka/forge/version";
  * await version({ release: true, target: true });
  * // 1.0.0 (release, aarch64-apple-darwin)
  * ```


### PR DESCRIPTION
When type-checking JSDoc examples, `deno check` injects context from surrounding code, but `flow check` will not.