### PR TITLE
fix(forge): fix `release` not working from outside the repo

### DIFF
--- a/tool/forge/release.ts
+++ b/tool/forge/release.ts
@@ -22,7 +22,6 @@
  */
 
 import { pool } from "@roka/async/pool";
-import { git } from "@roka/git";
 import {
   github,
   type Release,
@@ -89,7 +88,7 @@ export async function release(
   }
   const name = `${pkg.name}@${pkg.config.version}`;
   let [release] = await repo.releases.list({ name, draft });
-  const [head] = await git().commits.log();
+  const [head] = await repo.git.commits.log();
   if (!head) throw new PackageError("Cannot determine current commit");
   const data = {
     name,


### PR DESCRIPTION
This was causing test fragility.