### PR TITLE
ci: simplify coverage upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,6 @@ jobs:
       - name: Test
         run: deno task -q flow --check .
 
-      - name: Coverage
-        run: deno coverage --lcov --output=coverage/lcov.info
-
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/core/deno/deno.test.ts
+++ b/core/deno/deno.test.ts
@@ -44,7 +44,7 @@ Deno.test("deno().path() is persistent with absolute path", async () => {
   const repo = deno({ cwd: directory.path() });
   assertEquals(repo.path(), directory.path());
   {
-    const _ = await tempDirectory({ chdir: true });
+    await using _ = await tempDirectory({ chdir: true });
     assertEquals(resolve(repo.path()), directory.path());
   }
 });
@@ -57,7 +57,7 @@ Deno.test("deno().path() is persistent with relative path", async () => {
     await Deno.realPath(directory.path()),
   );
   {
-    const _ = await tempDirectory({ chdir: true });
+    await using _ = await tempDirectory({ chdir: true });
     assertEquals(
       await Deno.realPath(repo.path()),
       await Deno.realPath(directory.path()),

--- a/core/git/git.test.ts
+++ b/core/git/git.test.ts
@@ -62,7 +62,7 @@ Deno.test("git().path() is persistent with absolute path", async () => {
   const repo = git({ cwd: directory.path() });
   assertEquals(repo.path(), directory.path());
   {
-    const _ = await tempDirectory({ chdir: true });
+    await using _ = await tempDirectory({ chdir: true });
     assertEquals(resolve(repo.path()), directory.path());
   }
 });
@@ -75,7 +75,7 @@ Deno.test("git().path() is persistent with relative path", async () => {
     await Deno.realPath(directory.path()),
   );
   {
-    const _ = await tempDirectory({ chdir: true });
+    await using _ = await tempDirectory({ chdir: true });
     assertEquals(
       await Deno.realPath(repo.path()),
       await Deno.realPath(directory.path()),


### PR DESCRIPTION
These tests were altering the working directory, making coverage reporting fail.