### PR TITLE
fix(git): ignore missing output with `git().remote.clone({ directory })`

### DIFF
--- a/core/git/git.ts
+++ b/core/git/git.ts
@@ -1317,9 +1317,7 @@ export function git(options?: GitOptions): Git {
           "--",
           options?.directory,
         );
-        const match = output.match(
-          /Cloning into '(?<directory>.+?)'\.\.\./,
-        );
+        const match = output.match(/Cloning into '(?<directory>.+?)'\.\.\./);
         const cloned = options?.directory ?? match?.groups?.directory;
         assertExists(cloned, "Cannot determine cloned directory");
         const cwd = resolve(directory, cloned);


### PR DESCRIPTION
Determination of cloned directory is a bit brittle, this ensures the `directory` option does not have this problem.