### PR TITLE
fix(git): accept string URLs

### DIFF
--- a/core/git/testing.test.ts
+++ b/core/git/testing.test.ts
@@ -49,6 +49,11 @@ Deno.test("tempRepository({ branch }) sets default branch name", async () => {
 Deno.test("tempRepository({ clone }) clones a repo from another repo", async () => {
   await using remote = await tempRepository({ bare: true });
   await using repo = await tempRepository({ clone: remote });
+  assertEquals(await repo.remote.get(), {
+    name: "origin",
+    fetch: toFileUrl(remote.path()),
+    push: [toFileUrl(remote.path())],
+  });
   const commit = await repo.commit.create("commit", { allowEmpty: true });
   await repo.remote.push();
   assertEquals(await remote.commit.head(), commit);
@@ -57,6 +62,11 @@ Deno.test("tempRepository({ clone }) clones a repo from another repo", async () 
 Deno.test("tempRepository({ clone }) can clone a repo from path", async () => {
   await using remote = await tempRepository({ bare: true });
   await using repo = await tempRepository({ clone: remote.path() });
+  assertEquals(await repo.remote.get(), {
+    name: "origin",
+    fetch: toFileUrl(remote.path()),
+    push: [toFileUrl(remote.path())],
+  });
   const commit = await repo.commit.create("commit", { allowEmpty: true });
   await repo.remote.push();
   assertEquals(await remote.commit.head(), commit);
@@ -64,7 +74,13 @@ Deno.test("tempRepository({ clone }) can clone a repo from path", async () => {
 
 Deno.test("tempRepository({ clone }) can clone a repo from URL", async () => {
   await using remote = await tempRepository({ bare: true });
+  const url = toFileUrl(remote.path());
   await using repo = await tempRepository({ clone: toFileUrl(remote.path()) });
+  assertEquals(await repo.remote.get(), {
+    name: "origin",
+    fetch: url,
+    push: [url],
+  });
   const commit = await repo.commit.create("commit", { allowEmpty: true });
   await repo.remote.push();
   assertEquals(await remote.commit.head(), commit);

--- a/core/git/testing.ts
+++ b/core/git/testing.ts
@@ -16,7 +16,6 @@
  * @module testing
  */
 
-import { toFileUrl } from "@std/path";
 import { type Commit, type Config, type Git, git } from "./git.ts";
 
 /**
@@ -108,7 +107,9 @@ export async function tempRepository(
     ? await git().remote.clone(
       clone instanceof URL
         ? clone
-        : toFileUrl(typeof clone === "string" ? clone : clone.path()),
+        : typeof clone === "string"
+        ? clone
+        : clone.path(),
       { directory, bare, config, remote },
     )
     : await git().init({ bare, branch, config, directory });


### PR DESCRIPTION
Git distinguishes between local directory paths and `file:` URLs. Remote transport is used for the latter. Instead of unwrapping `file:` URLs, we will let the user choose which one they want.