### PR TITLE
refactor(git): use string literals for `tags`

### DIFF
--- a/core/git/git.test.ts
+++ b/core/git/git.test.ts
@@ -904,7 +904,7 @@ Deno.test("git().remote.fetch({ tags }) can skip tags", async () => {
   await using repo = await tempRepository({ clone: upstream });
   const commit = await upstream.commit.create("commit2", { allowEmpty: true });
   await upstream.tag.create("tag");
-  await repo.remote.fetch({ tags: false });
+  await repo.remote.fetch({ tags: "none" });
   assertEquals(await repo.branch.list({ name: "origin/main", remotes: true }), [
     { name: "origin/main", commit },
   ]);
@@ -947,7 +947,7 @@ Deno.test("git().remote.fetch({ tags }) can fetch all tags", async () => {
   await repo2.commit.create("commit2", { allowEmpty: true });
   const tag2 = await repo2.tag.create("tag2");
   await repo2.remote.push({ tag: tag2 });
-  await repo1.remote.fetch({ tags: true });
+  await repo1.remote.fetch({ tags: "all" });
   assertEquals(await repo1.tag.list(), [tag1, tag2]);
 });
 
@@ -1176,7 +1176,7 @@ Deno.test("git().remote.pull({ tags }) can skip tags", async () => {
   const tag = await repo2.tag.create("tag");
   await repo2.remote.push();
   await repo2.remote.push({ tag: tag });
-  await repo1.remote.pull({ tags: false });
+  await repo1.remote.pull({ tags: "none" });
   assertEquals(await repo1.commit.log(), [commit]);
   assertEquals(await repo1.tag.list(), []);
 });
@@ -1193,7 +1193,7 @@ Deno.test("git().remote.pull({ tags }) can fetch all tags", async () => {
   await repo2.commit.create("commit2", { allowEmpty: true });
   const tag2 = await repo2.tag.create("tag2");
   await repo2.remote.push({ tag: tag2 });
-  await repo1.remote.pull({ tags: true });
+  await repo1.remote.pull({ tags: "all" });
   assertEquals(await repo1.commit.log(), [commit]);
   assertEquals(await repo1.tag.list(), [tag1, tag2]);
 });
@@ -1383,7 +1383,7 @@ Deno.test("git().remote.push({ tags }) can push all tags", async () => {
   await repo.commit.create("commit", { allowEmpty: true });
   const tag1 = await repo.tag.create("tag1");
   const tag2 = await repo.tag.create("tag2");
-  await repo.remote.push({ tags: true });
+  await repo.remote.push({ tags: "all" });
   assertEquals(await upstream.tag.list(), [tag1, tag2]);
 });
 
@@ -1395,7 +1395,7 @@ Deno.test("git().remote.push({ tags }) can push all tags with multiple branches"
   await repo.branch.create("branch2");
   const tag1 = await repo.tag.create("tag1");
   const tag2 = await repo.tag.create("tag2");
-  await repo.remote.push({ tags: true, target: ["branch1", "branch2"] });
+  await repo.remote.push({ tags: "all", target: ["branch1", "branch2"] });
   assertEquals(await upstream.tag.list(), [tag1, tag2]);
   assertEquals(await upstream.branch.list(), [
     { name: "branch1", commit },
@@ -1407,7 +1407,7 @@ Deno.test("git().remote.push({ tags }) rejects pushing all tags with all branche
   await using upstream = await tempRepository({ bare: true });
   await using repo = await tempRepository({ clone: upstream });
   await assertRejects(
-    () => repo.remote.push({ tags: true, branches: "all" }),
+    () => repo.remote.push({ tags: "all", branches: "all" }),
     GitError,
     "cannot be used together",
   );

--- a/core/git/git.ts
+++ b/core/git/git.ts
@@ -686,13 +686,13 @@ export interface RemoteTransportOptions {
   /**
    * Control fetching or pushing tags.
    *
-   * - `true`: copy all tags
-   * - `false`: do not copy any tags (push default)
+   * - `"none"`: do not copy any tags (push default)
    * - `"follow"`: copy only tags that point to copied objects (fetch default)
+   * - `"all"`: copy all tags
    *
    * When pushing, only annotated tags are copied when following.
    */
-  tags?: boolean | "follow";
+  tags?: "none" | "follow" | "all";
 }
 
 /**
@@ -816,17 +816,11 @@ export type RemoteFetchOptions =
  */
 export interface RemoteFetchSingleOptions
   extends
+    RemoteRepositoryOptions,
     RemoteTransportOptions,
     RemoteTrackOptions,
     RemoteFilterOptions,
     RemoteShallowOptions {
-  /**
-   * Fetch from a repository, or multiple repositories.
-   *
-   * If omitted, fetches from the current branch remote, or `"origin"` if a
-   * remote is not configured for the current branch.
-   */
-  remote?: string | URL | Remote;
   /**
    * Branch or tag to fetch commits from.
    *
@@ -897,17 +891,11 @@ export type RemotePullOptions =
  */
 export interface RemotePullSingleOptions
   extends
+    RemoteRepositoryOptions,
     RemoteTransportOptions,
     RemoteTrackOptions,
     RemoteShallowOptions,
     SignOptions {
-  /**
-   * Pull from a repository, or from all repositories.
-   *
-   * If omitted, pulls from the current branch remote, or `"origin"` if a
-   * remote is not configured for the current branch.
-   */
-  remote?: string | URL | Remote;
   /**
    * Branch or tag to pull commits from.
    *
@@ -949,13 +937,18 @@ export type RemotePushOptions =
 export interface RemotePushBranchOptions
   extends
     RemoteRepositoryOptions,
+    RemoteTransportOptions,
     RemotePushForceOptions,
     RemoteTrackOptions,
-    RemoteTransportOptions {
+    SignOptions {
   /**
    * Branch or branches to push to remote.
    *
    * The default behavior is to push the current branch.
+   *
+   * Note that this does not accept tag names. To push tags, use
+   * {@linkcode RemotePushTagOptions.tag tag} or
+   * {@linkcode RemoteTransportOptions.tags tags}.
    */
   target?: string | Branch | (string | Branch)[];
   /**
@@ -975,9 +968,10 @@ export interface RemotePushBranchOptions
 export interface RemotePushAllBranchesOptions
   extends
     RemoteRepositoryOptions,
+    RemoteTransportOptions,
     RemotePushForceOptions,
     RemoteTrackOptions,
-    RemoteTransportOptions {
+    SignOptions {
   /** Push all branches to remote. */
   branches: "all";
   /**
@@ -997,9 +991,10 @@ export interface RemotePushAllBranchesOptions
 export interface RemotePushTagOptions
   extends
     RemoteRepositoryOptions,
+    RemoteTransportOptions,
     RemotePushForceOptions,
     RemoteTrackOptions,
-    RemoteTransportOptions {
+    SignOptions {
   /** Tag to push to remote. */
   tag: string | Tag;
   /**
@@ -1010,6 +1005,10 @@ export interface RemotePushTagOptions
    * Cannot be specified with {@linkcode RemotePushTagOptions.tag}.
    */
   branches?: never;
+  /**
+   * Cannot be specified with {@linkcode RemotePushTagOptions.tag}.
+   */
+  tags?: never;
 }
 
 /**
@@ -1652,8 +1651,8 @@ export function git(options?: GitOptions): Git {
           flag("--shallow-exclude", options?.shallow?.exclude, {
             equals: true,
           }),
-          flag("--tags", options?.tags === true),
-          flag("--no-tags", options?.tags === false),
+          flag("--no-tags", options?.tags === "none"),
+          flag("--tags", options?.tags === "all"),
           flag("--set-upstream", options?.track),
           flag("--all", options?.all),
           flag("--multiple", Array.isArray(options?.remote)),
@@ -1690,8 +1689,8 @@ export function git(options?: GitOptions): Git {
             equals: true,
           }),
           signFlag("commit", options?.sign),
-          flag("--tags", options?.tags === true),
-          flag("--no-tags", options?.tags === false),
+          flag("--no-tags", options?.tags === "none"),
+          flag("--tags", options?.tags === "all"),
           flag("--set-upstream", options?.track),
           flag("--all", options?.all),
           flag("--multiple", Array.isArray(options?.remote)),
@@ -1720,8 +1719,8 @@ export function git(options?: GitOptions): Git {
             "--force-if-includes",
             options?.force === "with-lease-if-includes",
           ),
-          flag("--tags", options?.tags === true),
-          flag("--no-tags", options?.tags === false),
+          flag("--no-tags", options?.tags === "none"),
+          flag("--tags", options?.tags === "all"),
           flag("--follow-tags", options?.tags === "follow"),
           flag("--set-upstream", options?.track),
           flag("--branches", options?.branches === "all"),


### PR DESCRIPTION
To be consistent with `branches` for push