### PR TITLE
chore: format files not supported by deno lsp

### DIFF
--- a/core/git/deno.json
+++ b/core/git/deno.json
@@ -10,8 +10,12 @@
     "permissions": {
       "read": true,
       "write": true,
-      "env": ["CODESPACES"],
-      "run": ["git"]
+      "env": [
+        "CODESPACES"
+      ],
+      "run": [
+        "git"
+      ]
     }
   }
 }

--- a/core/github/deno.json
+++ b/core/github/deno.json
@@ -9,7 +9,9 @@
     "permissions": {
       "read": true,
       "write": true,
-      "run": ["git"]
+      "run": [
+        "git"
+      ]
     }
   }
 }

--- a/core/http/deno.json
+++ b/core/http/deno.json
@@ -9,8 +9,12 @@
   },
   "test": {
     "permissions": {
-      "read": ["."],
-      "write": ["."]
+      "read": [
+        "."
+      ],
+      "write": [
+        "."
+      ]
     }
   }
 }

--- a/core/testing/deno.json
+++ b/core/testing/deno.json
@@ -10,7 +10,9 @@
     "permissions": {
       "read": true,
       "write": true,
-      "env": ["FAKE_ENV"]
+      "env": [
+        "FAKE_ENV"
+      ]
     }
   }
 }

--- a/deno.json
+++ b/deno.json
@@ -11,10 +11,16 @@
     "exactOptionalPropertyTypes": true,
     "noUncheckedIndexedAccess": true
   },
-  "exclude": ["**/__testdata__/**"],
+  "exclude": [
+    "**/__testdata__/**"
+  ],
   "lint": {
     "rules": {
-      "tags": ["recommended", "workspace", "jsr"],
+      "tags": [
+        "recommended",
+        "workspace",
+        "jsr"
+      ],
       "include": [
         "camelcase",
         "default-param-last",
@@ -52,5 +58,7 @@
     "@std/streams": "jsr:@std/streams@^1.0.12",
     "@std/testing": "jsr:@std/testing@^1.0.15"
   },
-  "unstable": ["kv"]
+  "unstable": [
+    "kv"
+  ]
 }

--- a/tool/flow/deno.json
+++ b/tool/flow/deno.json
@@ -11,7 +11,10 @@
     "default": {
       "read": true,
       "write": true,
-      "run": ["deno", "git"]
+      "run": [
+        "deno",
+        "git"
+      ]
     }
   }
 }

--- a/tool/forge/deno.json
+++ b/tool/forge/deno.json
@@ -16,11 +16,23 @@
   },
   "permissions": {
     "default": {
-      "env": ["GIT_NAME", "GIT_EMAIL", "GITHUB_TOKEN", "HOME"],
+      "env": [
+        "GIT_NAME",
+        "GIT_EMAIL",
+        "GITHUB_TOKEN",
+        "HOME"
+      ],
       "read": true,
       "write": true,
-      "net": ["api.github.com"],
-      "run": ["deno", "git", "tar", "zip"]
+      "net": [
+        "api.github.com"
+      ],
+      "run": [
+        "deno",
+        "git",
+        "tar",
+        "zip"
+      ]
     }
   },
   "test": {
@@ -28,8 +40,13 @@
       "read": true,
       "write": true,
       "run": true,
-      "env": ["GITHUB_TOKEN", "HOME"],
-      "net": ["api.github.com"]
+      "env": [
+        "GITHUB_TOKEN",
+        "HOME"
+      ],
+      "net": [
+        "api.github.com"
+      ]
     }
   }
 }


### PR DESCRIPTION
These are auto-formatted by zed (prettier?). Deno fmt is happy with it.
