### PR TITLE
refactor(git,github,forge): rename commit summary to subject

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,20 +127,23 @@ export function fibonacci(n: number): number {
 ❌ **Bad**: Redundant context in names
 
 ```ts
-export function parseCommit(commitMessage: string) {
+export function parseCommit(commitSubject: string) {
   const commitDelimiter = ": ";
-  const [commitType, commitSummary] = commitMessage.split(commitDelimiter, 2);
-  return { type: commitType, summary: commitSummary };
+  const [commitType, commitDescription] = commitSubject.split(
+    commitDelimiter,
+    2,
+  );
+  return { type: commitType, description: commitDescription };
 }
 ```
 
 ✅️ **Good**: Names without redundant context
 
 ```ts
-export function parseCommit(message: string) {
+export function parseCommit(subject: string) {
   const delimiter = ": ";
-  const [type, summary] = message.split(delimiter, 2);
-  return { type, summary };
+  const [type, description] = subject.split(delimiter, 2);
+  return { type, description };
 }
 ```
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -19,9 +19,9 @@ hard about how to use modules and functions.
 ✅️ **Good**: Simple function signature
 
 ```ts
-export function parse(message: string) {
-  const [type, summary] = message.split(": ", 2);
-  return { type, summary };
+export function parse(subject: string) {
+  const [type, description] = subject.split(": ", 2);
+  return { type, description };
 }
 ```
 
@@ -30,9 +30,9 @@ export function parse(message: string) {
 ```ts
 export function parser() {
   return {
-    parse(message: string) {
-      const [type, summary] = message.split(": ", 2);
-      return { type, summary };
+    parse(subject: string) {
+      const [type, description] = subject.split(": ", 2);
+      return { type, description };
     },
   };
 }
@@ -48,21 +48,21 @@ O(N) is just one more line.
 ✅️ **Good**: Simple and clear code
 
 ```ts
-export function parse(message: string) {
-  const [type, summary] = message.split(": ", 2);
-  return { type, summary };
+export function parse(subject: string) {
+  const [type, description] = subject.split(": ", 2);
+  return { type, description };
 }
 ```
 
 ❌ **Bad**: Premature optimization
 
 ```ts
-export function parse(message: string) {
-  const index = message.indexOf(": ");
-  if (index === -1) return { type: message, summary: undefined };
-  const type = message.substring(0, index);
-  const summary = message.substring(index + 2);
-  return { type, summary };
+export function parse(subject: string) {
+  const index = subject.indexOf(": ");
+  if (index === -1) return { type: subject, description: undefined };
+  const type = subject.substring(0, index);
+  const description = subject.substring(index + 2);
+  return { type, description };
 }
 ```
 
@@ -168,15 +168,15 @@ export interface ParseOptions {
   trim?: boolean;
 }
 
-export function parse(message: string, options?: ParseOptions) {
+export function parse(subject: string, options?: ParseOptions) {
   const { delimiter = ": ", strict = false, trim = false } = options ?? {};
-  const [type, summary] = message.split(delimiter, 2);
-  if (strict && (!type || !summary)) {
-    throw new Error("Invalid commit message format");
+  const [type, description] = subject.split(delimiter, 2);
+  if (strict && (!type || !description)) {
+    throw new Error("Invalid commit subject format");
   }
   return {
     type: trim ? type?.trim() : type,
-    summary: trim ? summary?.trim() : summary,
+    description: trim ? description?.trim() : description,
   };
 }
 ```
@@ -185,18 +185,18 @@ export function parse(message: string, options?: ParseOptions) {
 
 ```ts
 export function parse(
-  message: string,
+  subject: string,
   delimiter: string,
   strict: boolean,
   trim: boolean,
 ) {
-  const [type, summary] = message.split(delimiter, 2);
-  if (strict && (!type || !summary)) {
-    throw new Error("Invalid commit message format");
+  const [type, description] = subject.split(delimiter, 2);
+  if (strict && (!type || !description)) {
+    throw new Error("Invalid commit subject format");
   }
   return {
     type: trim ? type?.trim() : type,
-    summary: trim ? summary?.trim() : summary,
+    description: trim ? description?.trim() : description,
   };
 }
 ```
@@ -218,9 +218,9 @@ export function parse(
 ) {
   const { delimiter = ": " } = options ?? {};
   lines = typeof lines === "string" ? [lines] : lines;
-  return lines.map((message) => {
-    const [type, summary] = message.split(delimiter, 2);
-    return { type, summary };
+  return lines.map((subject) => {
+    const [type, description] = subject.split(delimiter, 2);
+    return { type, description };
   });
 }
 ```
@@ -233,8 +233,8 @@ export function parse(
   config: { delimiter?: string },
 ) {
   return input.lines?.map((x) => {
-    const [type, summary] = x.split(config.delimiter ?? ": ", 2);
-    return { type, summary };
+    const [type, description] = x.split(config.delimiter ?? ": ", 2);
+    return { type, description };
   }) ?? [];
 }
 const input = JSON.parse('{"lines":["feat: add new feature"]}');
@@ -255,18 +255,18 @@ improves type-safety for callers.
 ```ts
 export interface ParsedCommit {
   type: string;
-  summary: string;
+  description: string;
 }
 
-export function parse(message: string): ParsedCommit;
-export function parse(messages: string[]): ParsedCommit[];
+export function parse(subject: string): ParsedCommit;
+export function parse(subjects: string[]): ParsedCommit[];
 
 // the implementation body is not visible to outside
 export function parse(input: string | string[]) {
-  function inner(message: string) {
-    const [type, summary] = message.split(": ", 2);
-    if (!type || !summary) throw new Error("Invalid commit message format");
-    return { type, summary };
+  function inner(subject: string) {
+    const [type, description] = subject.split(": ", 2);
+    if (!type || !description) throw new Error("Invalid commit subject format");
+    return { type, description };
   }
   return (typeof input === "string") ? inner(input) : input.map(inner);
 }
@@ -277,14 +277,14 @@ export function parse(input: string | string[]) {
 ```ts
 export interface ParsedCommit {
   type: string;
-  summary: string;
+  description: string;
 }
 
 export function parse(input: string | string[]): ParsedCommit | ParsedCommit[] {
-  function inner(message: string) {
-    const [type, summary] = message.split(": ", 2);
-    if (!type || !summary) throw new Error("Invalid commit message format");
-    return { type, summary };
+  function inner(subject: string) {
+    const [type, description] = subject.split(": ", 2);
+    if (!type || !description) throw new Error("Invalid commit subject format");
+    return { type, description };
   }
   return (typeof input === "string") ? inner(input) : input.map(inner);
 }
@@ -299,27 +299,27 @@ nesting.
 ✅️ **Good**: Flat and concise code
 
 ```ts
-export function parse(message?: string) {
-  if (!message) return undefined;
-  const [type, summary] = message.split(": ", 2);
-  if (!summary) throw new Error("Missing summary");
-  return { type, summary };
+export function parse(subject?: string) {
+  if (!subject) return undefined;
+  const [type, description] = subject.split(": ", 2);
+  if (!description) throw new Error("Missing description");
+  return { type, description };
 }
 ```
 
 ❌ **Bad**: Overly nested code
 
 ```ts
-export function parse(message?: string) {
-  if (message !== undefined) {
-    if (message.length > 0) {
-      const parts = message.split(": ", 2);
+export function parse(subject?: string) {
+  if (subject !== undefined) {
+    if (subject.length > 0) {
+      const parts = subject.split(": ", 2);
       const type = parts[0];
-      const summary = parts[1];
-      if (summary !== undefined) {
-        return { type, summary };
+      const description = parts[1];
+      if (description !== undefined) {
+        return { type, description };
       } else {
-        throw new Error("Missing summary");
+        throw new Error("Missing description");
       }
     } else {
       return undefined;
@@ -339,26 +339,26 @@ can't be expressed clearly otherwise.
 ✅️ **Good**: Clear code without inline comments
 
 ```ts
-export function parse(message: string) {
-  if (!message) return undefined;
-  const [type, summary] = message.split(": ", 2);
-  if (!summary) throw new Error("Missing summary");
-  return { type, summary };
+export function parse(subject: string) {
+  if (!subject) return undefined;
+  const [type, description] = subject.split(": ", 2);
+  if (!description) throw new Error("Missing description");
+  return { type, description };
 }
 ```
 
 ❌ **Bad**: Inline comments narrating code
 
 ```ts
-export function parse(message: string) {
-  // Check if message exists
-  if (!message) return undefined;
-  // Split the message into parts
-  const [type, summary] = message.split(": ", 2);
-  // Validate that we have a summary
-  if (!summary) throw new Error("Missing summary");
+export function parse(subject: string) {
+  // Check if subject exists
+  if (!subject) return undefined;
+  // Split the subject into parts
+  const [type, description] = subject.split(": ", 2);
+  // Validate that we have a description
+  if (!description) throw new Error("Missing description");
   // Return the parsed result
-  return { type, summary };
+  return { type, description };
 }
 ```
 
@@ -372,27 +372,30 @@ _"url"_, or _"cwd"_).
 ✅️ **Good**: Clear and appropriately scoped
 
 ```ts
-export function parse(message: string, delimiter: string = ": ") {
-  const [type, summary] = message.split(delimiter, 2);
-  return { type, summary };
+export function parse(subject: string, delimiter: string = ": ") {
+  const [type, description] = subject.split(delimiter, 2);
+  return { type, description };
 }
 ```
 
 ❌ **Bad**: Unnecessarily verbose
 
 ```ts
-export function parse(commitMessage: string, splitDelimiter: string = ": ") {
-  const commitTypeAndSummary = commitMessage.split(splitDelimiter, 2);
-  return { type: commitTypeAndSummary[0], summary: commitTypeAndSummary[1] };
+export function parse(commitSubject: string, splitDelimiter: string = ": ") {
+  const commitTypeAndDescription = commitSubject.split(splitDelimiter, 2);
+  return {
+    type: commitTypeAndDescription[0],
+    description: commitTypeAndDescription[1],
+  };
 }
 ```
 
 ❌ **Bad**: Unclear abbreviations
 
 ```ts
-export function parse(msg: string, delim: string = ": ") {
-  const [type, summary] = msg.split(delim, 2);
-  return { type, summary };
+export function parse(sub: string, delim: string = ": ") {
+  const [type, desc] = sub.split(delim, 2);
+  return { type, desc };
 }
 ```
 
@@ -409,12 +412,12 @@ interfaces. Use the `type` keyword only for type manipulation.
 ```ts
 export interface ParsedCommit {
   type: string;
-  summary: string;
+  description: string;
 }
 
 export class ParseError extends Error {
-  constructor(message: string, cause?: Error) {
-    super(message, { cause });
+  constructor(subject: string, cause?: Error) {
+    super(subject, { cause });
     this.name = "ParseError";
   }
 }
@@ -464,14 +467,14 @@ throwing an error is acceptable to keep the types simpler.
 ```ts
 export interface ParsedCommit {
   type: string;
-  summary: string;
+  description: string;
 }
 
-export function parse(message?: string): ParsedCommit | undefined {
-  if (!message) return undefined;
-  const [type, summary] = message.split(": ", 2);
-  if (!type || !summary) throw new Error("Invalid commit message format");
-  return { type, summary };
+export function parse(subject?: string): ParsedCommit | undefined {
+  if (!subject) return undefined;
+  const [type, description] = subject.split(": ", 2);
+  if (!type || !description) throw new Error("Invalid commit subject format");
+  return { type, description };
 }
 ```
 
@@ -494,16 +497,18 @@ custom error class per package. For example, `@roka/git` has `GitError`.
 
 ```ts
 export class ParseError extends Error {
-  constructor(message: string) {
-    super(message);
+  constructor(subject: string) {
+    super(subject);
     this.name = "ParseError";
   }
 }
 
-export function parse(message: string) {
-  const [type, summary] = message.split(": ", 2);
-  if (!type || !summary) throw new ParseError("Invalid commit message format");
-  return { type, summary };
+export function parse(subject: string) {
+  const [type, description] = subject.split(": ", 2);
+  if (!type || !description) {
+    throw new ParseError("Invalid commit subject format");
+  }
+  return { type, description };
 }
 ```
 
@@ -517,17 +522,17 @@ the `cause`.
 
 ```ts
 export class ParseError extends Error {
-  constructor(message: string, options?: { cause?: unknown }) {
-    super(message, options);
+  constructor(subject: string, options?: { cause?: unknown }) {
+    super(subject, options);
     this.name = "ParseError";
   }
 }
 
 export async function parse(path: string) {
   try {
-    const message = await Deno.readTextFile(path);
-    const [type, summary] = message.split(": ", 2);
-    return { type, summary };
+    const subject = await Deno.readTextFile(path);
+    const [type, description] = subject.split(": ", 2);
+    return { type, description };
   } catch (error) {
     throw new ParseError("Failed to read file", { cause: error });
   }
@@ -544,29 +549,29 @@ include sensitive data like tokens or passwords.
 ✅️ **Good**: Clear messages
 
 ```ts
-export function parse(message: string) {
-  if (!message) throw new Error("Input is empty");
-  const [type, summary] = message.split(": ", 2);
-  if (!type || !summary) {
+export function parse(subject: string) {
+  if (!subject) throw new Error("Subject not provided");
+  const [type, description] = subject.split(": ", 2);
+  if (!type || !description) {
     throw new Error([
-      `Invalid commit message format: ${message}`,
+      `Invalid commit subject format: ${subject}`,
       "  Expected delimiter: ':'",
     ].join("\n\n"));
   }
-  return { type, summary };
+  return { type, description };
 }
 ```
 
 ❌ **Bad**: Vague or redundant messages
 
 ```ts
-export function parse(message: string) {
-  if (!message) throw new Error("Error"); // too vague
-  const [type, summary] = message.split(": ", 2);
-  if (!type || !summary) {
-    throw new Error("Error: invalid commit message format"); // redundant prefix
+export function parse(subject: string) {
+  if (!subject) throw new Error("Error"); // too vague
+  const [type, description] = subject.split(": ", 2);
+  if (!type || !description) {
+    throw new Error("Error: invalid commit subject format"); // redundant prefix
   }
-  return { type, summary };
+  return { type, description };
 }
 ```
 
@@ -583,13 +588,13 @@ treat their failures as bugs.
 ```ts
 import { assertExists } from "@std/assert";
 
-export function parse(message: string, delimiter = ":") {
-  if (!message) return undefined;
-  const parts = message.split(delimiter, 2);
+export function parse(subject: string, delimiter = ":") {
+  if (!subject) return undefined;
+  const parts = subject.split(delimiter, 2);
   const type = parts[0];
   assertExists(type); // type narrowing
-  const summary = parts[1];
-  return { type, summary };
+  const description = parts[1];
+  return { type, description };
 }
 ```
 
@@ -606,15 +611,15 @@ demonstrating how the code functions.
 ```ts
 import { assertEquals } from "@std/assert";
 
-export function parse(message: string) {
-  const [type, summary] = message.split(": ", 2);
-  return { type, summary };
+export function parse(subject: string) {
+  const [type, description] = subject.split(": ", 2);
+  return { type, description };
 }
 
-Deno.test("parse() returns commit type and summary", () => {
+Deno.test("parse() returns commit type and description", () => {
   assertEquals(parse("feat: add new feature"), {
     type: "feat",
-    summary: "add new feature",
+    description: "add new feature",
   });
 });
 ```
@@ -624,25 +629,25 @@ Deno.test("parse() returns commit type and summary", () => {
 ```ts
 import { assertEquals } from "@std/assert";
 
-export function parse(message: string) {
-  const [type, summary] = message.split(": ", 2);
-  return { type, summary };
+export function parse(subject: string) {
+  const [type, description] = subject.split(": ", 2);
+  return { type, description };
 }
 
-Deno.test("parse() returns commit type and summary", () => {
-  // Given a conventional commit message
-  const message = "feat: add new feature";
-  // When we parse the message
-  const result = parse(message);
+Deno.test("parse() returns commit type and description", () => {
+  // Given a conventional commit subject
+  const subject = "feat: add new feature";
+  // When we parse the subject
+  const result = parse(subject);
   // Then we expect the type to be "feat"
   assertEquals(result.type, "feat");
-  // And we expect the summary to be "add new feature"
-  assertEquals(result.summary, "add new feature");
+  // And we expect the description to be "add new feature"
+  assertEquals(result.description, "add new feature");
   // Verify the result object is serializable
   // This ensures no functions or complex types are returned
   assertEquals(JSON.parse(JSON.stringify(result)), {
     type: "feat",
-    summary: "add new feature",
+    description: "add new feature",
   });
   // End of test
 });
@@ -659,8 +664,8 @@ the test code.
 ✅️ **Good**: Explicit test names
 
 ```ts
-Deno.test("parse() extracts type and summary from message", () => {});
-Deno.test("parse() rejects empty commit message", () => {});
+Deno.test("parse() extracts type and description from subject", () => {});
+Deno.test("parse() rejects empty commit subject", () => {});
 Deno.test("parse({ delimiter }) splits by custom delimiter", () => {});
 ```
 
@@ -682,13 +687,13 @@ conditions.
 💡 **Example**: Ordering tests
 
 ```ts
-Deno.test("parse() extracts type and summary from message", () => {});
-Deno.test("parse() handles messages without type", () => {});
-Deno.test("parse() rejects empty commit message", () => {});
+Deno.test("parse() extracts type and description from subject", () => {});
+Deno.test("parse() handles subjects without type", () => {});
+Deno.test("parse() rejects empty commit subject", () => {});
 Deno.test("parse({ delimiter }) splits by custom delimiter", () => {});
 Deno.test("parse({ delimiter }) can split by regular expression", () => {});
-Deno.test("parse({ strict }) rejects invalid commit message format", () => {});
-Deno.test("parse({ trim }) trims type and summary", () => {});
+Deno.test("parse({ strict }) rejects invalid commit subject format", () => {});
+Deno.test("parse({ trim }) trims type and description", () => {});
 ```
 
 ### Add tests for testing utilities
@@ -702,13 +707,13 @@ false positives, shipped bugs, and hours of debugging.
 ```ts
 import { assertEquals } from "@std/assert";
 
-export function testMessage(type: string) {
-  return `${type}: commit message`;
+export function testSubject(type: string) {
+  return `${type}: commit subject`;
 }
 
-Deno.test("testMessage() returns commit message", () => {
-  assertEquals(testMessage("feat"), "feat: commit message");
-  assertEquals(testMessage("fix"), "fix: commit message");
+Deno.test("testSubject() returns commit subject", () => {
+  assertEquals(testSubject("feat"), "feat: commit subject");
+  assertEquals(testSubject("fix"), "fix: commit subject");
 });
 ```
 
@@ -727,15 +732,15 @@ names and descriptions.
 
 ```ts
 /**
- * Parses a conventional commit message into its components.
+ * Parses a conventional commit subject into its components.
  *
- * @param delimiter Delimiter string separating type and summary.
- * @throws {Error} If the message format is invalid.
+ * @param delimiter Delimiter string separating type and description.
+ * @throws {Error} If the subject format is invalid.
  */
-export function parse(message: string, delimiter: string = ": ") {
-  const [type, summary] = message.split(delimiter, 2);
-  if (!type || !summary) throw new Error("Invalid commit message format");
-  return { type, summary };
+export function parse(subject: string, delimiter: string = ": ") {
+  const [type, description] = subject.split(delimiter, 2);
+  if (!type || !description) throw new Error("Invalid commit subject format");
+  return { type, description };
 }
 ```
 
@@ -743,16 +748,16 @@ export function parse(message: string, delimiter: string = ": ") {
 
 ```ts
 /**
- * Parses a message.
+ * Parses a subject.
  *
- * @param {string} message - The message.
+ * @param {string} subject - The subject.
  * @param {string} delimiter - The delimiter.
  * @returns The parsed string.
  */
-export function parse(message: string, delimiter: string = ": ") {
-  const [type, summary] = message.split(delimiter, 2);
-  if (!type || !summary) throw new Error("Invalid commit message format");
-  return { type, summary };
+export function parse(subject: string, delimiter: string = ": ") {
+  const [type, description] = subject.split(delimiter, 2);
+  if (!type || !description) throw new Error("Invalid commit subject format");
+  return { type, description };
 }
 ```
 
@@ -767,7 +772,7 @@ right module for their needs. Examples should be valid code snippets.
 ````ts
 /**
  * This module provides the {@linkcode parse} function for parsing and
- * validating conventional commit messages.
+ * validating conventional commit subjects.
  *
  * @example
  * ```
@@ -775,7 +780,7 @@ right module for their needs. Examples should be valid code snippets.
  * import { assertEquals } from "@std/assert";
  *
  * const result = parse("feat: add new feature");
- * assertEquals(result, { type: "feat", summary: "add new feature" });
+ * assertEquals(result, { type: "feat", description: "add new feature" });
  * ```
  *
  * @module parse
@@ -793,14 +798,14 @@ fields that begin with a verb.
 ✅️ **Good**: Indicative mood
 
 ```ts
-/** Parses a conventional commit message into its components. */
+/** Parses a conventional commit subject into its components. */
 export function parse() {}
 
 /**
  * Options for the {@linkcode parse} function.
  */
 export interface ParseOptions {
-  /** Splits the message using the given delimiter. */
+  /** Splits the subject using the given delimiter. */
   delimiter?: string;
 }
 ```
@@ -808,14 +813,14 @@ export interface ParseOptions {
 ❌ **Bad**: Imperative mood
 
 ```ts
-/** Parse a conventional commit message into its components. */
+/** Parse a conventional commit subject into its components. */
 export function parse() {}
 
 /**
  * Options for the {@linkcode parse} function.
  */
 export interface ParseOptions {
-  /** Split the message using the given delimiter. */
+  /** Split the subject using the given delimiter. */
   delimiter?: string;
 }
 ```
@@ -831,14 +836,14 @@ current state of the code, and not as a replacement for issue tracking. Keep
 
 ```ts
 /**
- * Parses a conventional commit message into its components.
+ * Parses a conventional commit subject into its components.
  *
  * @todo Add support for multi-line commit bodies.
  * @todo Validate commit type against allowed types.
  */
-export function parse(message: string) {
-  const [type, summary] = message.split(": ", 2);
-  return { type, summary };
+export function parse(subject: string) {
+  const [type, description] = subject.split(": ", 2);
+  return { type, description };
 }
 ```
 
@@ -849,19 +854,19 @@ All JSDoc sentences should end with proper punctuation.
 ✅️ **Good**: Sentence with punctuation
 
 ```ts
-/** Parses a conventional commit message. */
-export function parse(message: string) {
-  const [type, summary] = message.split(": ", 2);
-  return { type, summary };
+/** Parses a conventional commit subject. */
+export function parse(subject: string) {
+  const [type, description] = subject.split(": ", 2);
+  return { type, description };
 }
 ```
 
 ❌ **Bad**: Sentence without punctuation
 
 ```ts
-/** Parses a conventional commit message */
-export function parse(message: string) {
-  const [type, summary] = message.split(": ", 2);
-  return { type, summary };
+/** Parses a conventional commit subject */
+export function parse(subject: string) {
+  const [type, description] = subject.split(": ", 2);
+  return { type, description };
 }
 ```

--- a/core/git/conventional.test.ts
+++ b/core/git/conventional.test.ts
@@ -3,7 +3,7 @@ import { assertEquals } from "@std/assert";
 import { conventional } from "./conventional.ts";
 
 Deno.test("conventional() creates conventional commits", () => {
-  const commit = testCommit({ summary: "feat(scope): description" });
+  const commit = testCommit({ subject: "feat(scope): description" });
   assertEquals(conventional(commit), {
     ...commit,
     description: "description",
@@ -14,7 +14,7 @@ Deno.test("conventional() creates conventional commits", () => {
 });
 
 Deno.test("conventional() accepts simple commits", () => {
-  const commit = testCommit({ summary: "description" });
+  const commit = testCommit({ subject: "description" });
   assertEquals(conventional(commit), {
     ...commit,
     description: "description",
@@ -24,7 +24,7 @@ Deno.test("conventional() accepts simple commits", () => {
 });
 
 Deno.test("conventional() accepts commits without scope", () => {
-  const commit = testCommit({ summary: "feat: description" });
+  const commit = testCommit({ subject: "feat: description" });
   assertEquals(conventional(commit), {
     ...commit,
     description: "description",
@@ -35,7 +35,7 @@ Deno.test("conventional() accepts commits without scope", () => {
 });
 
 Deno.test("conventional() accepts empty scope", () => {
-  const commit = testCommit({ summary: "feat(): description" });
+  const commit = testCommit({ subject: "feat(): description" });
   assertEquals(conventional(commit), {
     ...commit,
     description: "description",
@@ -46,7 +46,7 @@ Deno.test("conventional() accepts empty scope", () => {
 });
 
 Deno.test("conventional() accepts empty scopes", () => {
-  const commit = testCommit({ summary: "feat(,): description" });
+  const commit = testCommit({ subject: "feat(,): description" });
   assertEquals(conventional(commit), {
     ...commit,
     type: "feat",
@@ -57,7 +57,7 @@ Deno.test("conventional() accepts empty scopes", () => {
 });
 
 Deno.test("conventional() can create multiple scopes", () => {
-  const commit = testCommit({ summary: "feat(scope1,scope2): description" });
+  const commit = testCommit({ subject: "feat(scope1,scope2): description" });
   assertEquals(conventional(commit), {
     ...commit,
     description: "description",
@@ -68,7 +68,7 @@ Deno.test("conventional() can create multiple scopes", () => {
 });
 
 Deno.test("conventional() accepts uppercase type and scopes", () => {
-  const commit = testCommit({ summary: "FEAT(SCOPE): description" });
+  const commit = testCommit({ subject: "FEAT(SCOPE): description" });
   assertEquals(conventional(commit), {
     ...commit,
     description: "description",
@@ -79,19 +79,19 @@ Deno.test("conventional() accepts uppercase type and scopes", () => {
 });
 
 Deno.test("conventional() accepts no space after scope", () => {
-  const commit = testCommit({ summary: "feat:summary" });
+  const commit = testCommit({ subject: "feat:description" });
   assertEquals(conventional(commit), {
     ...commit,
-    description: "summary",
+    description: "description",
     type: "feat",
     scopes: [],
     footers: {},
   });
 });
 
-Deno.test("conventional() accepts wild summary formatting", () => {
+Deno.test("conventional() accepts wild subject formatting", () => {
   const commit = testCommit({
-    summary: " feat(  scoPE1, SCOPe2  ):  description ",
+    subject: " feat(  scoPE1, SCOPe2  ):  description ",
   });
   assertEquals(conventional(commit), {
     ...commit,
@@ -103,7 +103,7 @@ Deno.test("conventional() accepts wild summary formatting", () => {
 });
 
 Deno.test("conventional() accepts scope with backticks", () => {
-  const commit = testCommit({ summary: "feat(`scope`): description" });
+  const commit = testCommit({ subject: "feat(`scope`): description" });
   assertEquals(conventional(commit), {
     ...commit,
     type: "feat",
@@ -114,7 +114,7 @@ Deno.test("conventional() accepts scope with backticks", () => {
 });
 
 Deno.test("conventional() can create breaking commits", () => {
-  const commit = testCommit({ summary: "feat!: description" });
+  const commit = testCommit({ subject: "feat!: description" });
   assertEquals(conventional(commit), {
     ...commit,
     description: "description",
@@ -127,7 +127,7 @@ Deno.test("conventional() can create breaking commits", () => {
 
 Deno.test("conventional() can create breaking commits from trailers", () => {
   const commit = testCommit({
-    summary: "feat: description",
+    subject: "feat: description",
     trailers: { "BREAKING-CHANGE": "breaking" },
   });
   assertEquals(conventional(commit), {
@@ -142,7 +142,7 @@ Deno.test("conventional() can create breaking commits from trailers", () => {
 
 Deno.test("conventional() can create breaking commits from body footer", () => {
   const commit = testCommit({
-    summary: "feat: description",
+    subject: "feat: description",
     body: "BREAKING-CHANGE: breaking",
   });
   assertEquals(conventional(commit), {
@@ -157,7 +157,7 @@ Deno.test("conventional() can create breaking commits from body footer", () => {
 
 Deno.test("conventional() breaking footer can contain whitespace", () => {
   const commit = testCommit({
-    summary: "feat: description",
+    subject: "feat: description",
     body: "BREAKING CHANGE: breaking",
   });
   assertEquals(conventional(commit), {
@@ -171,7 +171,7 @@ Deno.test("conventional() breaking footer can contain whitespace", () => {
 });
 
 Deno.test("conventional() can create breaking commit with scope", () => {
-  const commit = testCommit({ summary: "feat(scope)!: description" });
+  const commit = testCommit({ subject: "feat(scope)!: description" });
   assertEquals(conventional(commit), {
     ...commit,
     description: "description",
@@ -183,7 +183,7 @@ Deno.test("conventional() can create breaking commit with scope", () => {
 });
 
 Deno.test("conventional() commits must have a description", () => {
-  const commit = testCommit({ summary: "feat(scope): " });
+  const commit = testCommit({ subject: "feat(scope): " });
   assertEquals(conventional(commit), {
     ...commit,
     description: "feat(scope): ",
@@ -194,7 +194,7 @@ Deno.test("conventional() commits must have a description", () => {
 
 Deno.test("conventional() can parse footers", () => {
   const commit = testCommit({
-    summary: "feat(scope): description",
+    subject: "feat(scope): description",
     body: "Detailed commit explanation.\n\nFixes #123\nCloses #456",
   });
   assertEquals(conventional(commit), {

--- a/core/git/conventional.ts
+++ b/core/git/conventional.ts
@@ -70,7 +70,7 @@ export interface ConventionalCommit extends Commit {
 export function conventional(commit: Commit): ConventionalCommit {
   const footers = extractFooters(commit);
   const footerBreaking = footers["BREAKING-CHANGE"];
-  const match = commit.summary?.match(
+  const match = commit.subject?.match(
     /^(?:\s*?(?<type>[a-zA-Z]+)(?:\((?<scopes>[^()]*)\s*?\))?(?<exclamation>!?):\s*)?\s*?(?<description>[^\s].*)$/,
   );
   const { type, scopes, exclamation, description } = { ...match?.groups };

--- a/core/git/git.test.ts
+++ b/core/git/git.test.ts
@@ -1035,7 +1035,7 @@ Deno.test("git().index.add() adds files", async () => {
   ]);
 });
 
-Deno.test("git().index.add() rejects non-existent file", async () => {
+Deno.test("git().index.add() rejects unknown file", async () => {
   await using repo = await tempRepository();
   await assertRejects(
     () => repo.index.add("file"),
@@ -1137,7 +1137,7 @@ Deno.test("git().index.move() rejects missing destination if moving multiple fil
   assertEquals((await repo.index.status()).staged, []);
 });
 
-Deno.test("git().index.move() rejects non-existent source file", async () => {
+Deno.test("git().index.move() rejects unknown source file", async () => {
   await using repo = await tempRepository();
   await assertRejects(
     () => repo.index.move("old.file", "new.file"),
@@ -1334,7 +1334,7 @@ Deno.test("git().index.remove() removes files", async () => {
   ]);
 });
 
-Deno.test("git().index.remove() rejects non-existent file", async () => {
+Deno.test("git().index.remove() rejects unknown file", async () => {
   await using repo = await tempRepository();
   await assertRejects(
     () => repo.index.remove("file"),
@@ -1502,7 +1502,7 @@ Deno.test("git().diff.status({ path }) filters by path", async () => {
     { path: "file1", status: "modified" },
     { path: "file2", status: "modified" },
   ]);
-  assertEquals(await repo.diff.status({ path: "nonexistent" }), []);
+  assertEquals(await repo.diff.status({ path: "unknown" }), []);
 });
 
 Deno.test("git().diff.status({ pickaxe }) finds added and deleted lines", async () => {
@@ -2496,7 +2496,7 @@ Deno.test("git().ignore.filter() handles empty array", async () => {
   assertEquals(await repo.ignore.filter([]), []);
 });
 
-Deno.test("git().ignore.filter() works with nonexistent files", async () => {
+Deno.test("git().ignore.filter() works with unknown files", async () => {
   await using repo = await tempRepository();
   await Deno.writeTextFile(repo.path(".gitignore"), "*.log");
   assertEquals(await repo.ignore.filter("ignored.log"), ["ignored.log"]);
@@ -2555,7 +2555,7 @@ Deno.test("git().ignore.omit() handles empty array", async () => {
   assertEquals(await repo.ignore.omit([]), []);
 });
 
-Deno.test("git().ignore.omit() works with nonexistent files", async () => {
+Deno.test("git().ignore.omit() works with unknown files", async () => {
   await using repo = await tempRepository();
   await Deno.writeTextFile(repo.path(".gitignore"), "*.log");
   assertEquals(await repo.ignore.omit("ignored.log"), []);
@@ -2596,11 +2596,11 @@ Deno.test("git().commit.log() returns multiple commits", async () => {
 Deno.test("git().commit.log() can parse message body", async () => {
   await using repo = await tempRepository();
   await repo.commit.create(
-    "summary\n\nbody\n\nkey1: value1\nkey2: value2\n",
+    "subject\n\nbody\n\nkey1: value1\nkey2: value2\n",
     { allowEmpty: true },
   );
   const [commit] = await repo.commit.log();
-  assertEquals(commit?.summary, "summary");
+  assertEquals(commit?.subject, "subject");
   assertEquals(commit?.body, "body");
   assertEquals(commit?.trailers, { key1: "value1", key2: "value2" });
 });
@@ -2610,11 +2610,11 @@ Deno.test("git().commit.log() can work with custom trailer separator", async () 
     config: { trailer: { separators: "#" } },
   });
   await repo.commit.create(
-    "summary\n\nbody\n\nkey1 #value1\nkey2 #value2\n",
+    "subject\n\nbody\n\nkey1 #value1\nkey2 #value2\n",
     { allowEmpty: true },
   );
   const [commit] = await repo.commit.log();
-  assertEquals(commit?.summary, "summary");
+  assertEquals(commit?.subject, "subject");
   assertEquals(commit?.body, "body");
   assertEquals(commit?.trailers, { key1: "value1", key2: "value2" });
 });
@@ -2924,7 +2924,7 @@ Deno.test("git().commit.get() returns a commit by relative reference", async () 
   assertEquals(await repo.commit.get("HEAD~1"), commit1);
 });
 
-Deno.test("git().commit.get() handles non-existent commit", async () => {
+Deno.test("git().commit.get() handles unknown commit", async () => {
   await using repo = await tempRepository();
   assertEquals(await repo.commit.get("unknown"), undefined);
 });
@@ -2933,13 +2933,13 @@ Deno.test("git().commit.create() creates a commit", async () => {
   await using repo = await tempRepository();
   await Deno.writeTextFile(repo.path("file"), "content");
   await repo.index.add("file");
-  const commit = await repo.commit.create("summary");
-  assertEquals(commit?.summary, "summary");
+  const commit = await repo.commit.create("subject");
+  assertEquals(commit?.subject, "subject");
   assertEquals(commit?.body, undefined);
   assertEquals(commit?.trailers, {});
 });
 
-Deno.test("git().commit.create() rejects empty summary", async () => {
+Deno.test("git().commit.create() rejects empty subject", async () => {
   await using repo = await tempRepository();
   await assertRejects(
     () => repo.commit.create("", { allowEmpty: true }),
@@ -2991,8 +2991,8 @@ Deno.test("git().commit.create({ all }) can automatically remove files", async (
 
 Deno.test("git().commit.create({ allowEmpty }) allows empty commit", async () => {
   await using repo = await tempRepository();
-  const commit = await repo.commit.create("summary", { allowEmpty: true });
-  assertEquals(commit?.summary, "summary");
+  const commit = await repo.commit.create("subject", { allowEmpty: true });
+  assertEquals(commit?.subject, "subject");
 });
 
 Deno.test("git().commit.create({ author }) sets author", async () => {
@@ -3026,8 +3026,8 @@ Deno.test("git().commit.create({ body }) creates a commit with body", async () =
   await using repo = await tempRepository();
   await Deno.writeTextFile(repo.path("file"), "content");
   await repo.index.add("file");
-  const commit = await repo.commit.create("summary", { body: "body" });
-  assertEquals(commit?.summary, "summary");
+  const commit = await repo.commit.create("subject", { body: "body" });
+  assertEquals(commit?.subject, "subject");
   assertEquals(commit?.body, "body");
   assertEquals(commit?.trailers, {});
 });
@@ -3036,8 +3036,8 @@ Deno.test("git().commit.create({ body }) ignores empty body", async () => {
   await using repo = await tempRepository();
   await Deno.writeTextFile(repo.path("file"), "content");
   await repo.index.add("file");
-  const commit = await repo.commit.create("summary", { body: "" });
-  assertEquals(commit?.summary, "summary");
+  const commit = await repo.commit.create("subject", { body: "" });
+  assertEquals(commit?.subject, "subject");
   assertEquals(commit?.body, undefined);
   assertEquals(commit?.trailers, {});
 });
@@ -3077,10 +3077,10 @@ Deno.test("git().commit.create({ trailers }) creates a commit with trailers", as
   await using repo = await tempRepository();
   await Deno.writeTextFile(repo.path("file"), "content");
   await repo.index.add("file");
-  const commit = await repo.commit.create("summary", {
+  const commit = await repo.commit.create("subject", {
     trailers: { key1: "value1", key2: "value2\n  multi\n  line" },
   });
-  assertEquals(commit?.summary, "summary");
+  assertEquals(commit?.subject, "subject");
   assertEquals(commit?.body, undefined);
   assertEquals(commit?.trailers, { key1: "value1", key2: "value2 multi line" });
 });
@@ -3089,11 +3089,11 @@ Deno.test("git().commit.create({ trailers }) can create a commit with body and t
   await using repo = await tempRepository();
   await Deno.writeTextFile(repo.path("file"), "content");
   await repo.index.add("file");
-  const commit = await repo.commit.create("summary", {
+  const commit = await repo.commit.create("subject", {
     body: "body",
     trailers: { key: "value" },
   });
-  assertEquals(commit?.summary, "summary");
+  assertEquals(commit?.subject, "subject");
   assertEquals(commit?.body, "body");
   assertEquals(commit?.trailers, { key: "value" });
 });
@@ -3102,11 +3102,11 @@ Deno.test("git().commit.amend() amends last commit without changing message", as
   await using repo = await tempRepository();
   await Deno.writeTextFile(repo.path("file1"), "content");
   await repo.index.add("file1");
-  const original = await repo.commit.create("summary", { body: "body" });
+  const original = await repo.commit.create("subject", { body: "body" });
   await Deno.writeTextFile(repo.path("file2"), "content");
   await repo.index.add("file2");
   const amended = await repo.commit.amend();
-  assertEquals(amended.summary, "summary");
+  assertEquals(amended.subject, "subject");
   assertEquals(amended.body, "body");
   assertNotEquals(amended.hash, original.hash);
   assertEquals(await repo.commit.log(), [amended]);
@@ -3128,7 +3128,7 @@ Deno.test("git().commit.amend({ all }) automatically stages files", async () => 
   await repo.commit.create("commit");
   await Deno.writeTextFile(repo.path("file"), "modified content");
   const amended = await repo.commit.amend({ all: true });
-  assertEquals(amended.summary, "commit");
+  assertEquals(amended.subject, "commit");
   assertEquals(await repo.index.status(), {
     staged: [],
     unstaged: [],
@@ -3144,7 +3144,7 @@ Deno.test("git().commit.amend({ all }) can automatically remove files", async ()
   await repo.commit.create("commit");
   await Deno.remove(repo.path("file"));
   const amended = await repo.commit.amend({ all: true, allowEmpty: true });
-  assertEquals(amended.summary, "commit");
+  assertEquals(amended.subject, "commit");
   assertEquals(await repo.index.status(), {
     staged: [],
     unstaged: [],
@@ -3171,22 +3171,22 @@ Deno.test("git().commit.amend({ body }) changes the commit body", async () => {
   await using repo = await tempRepository();
   await Deno.writeTextFile(repo.path("file"), "content");
   await repo.index.add("file");
-  await repo.commit.create("summary");
+  await repo.commit.create("subject");
   const amended = await repo.commit.amend({
-    summary: "new summary",
+    subject: "new subject",
     body: "new body",
   });
-  assertEquals(amended.summary, "new summary");
+  assertEquals(amended.subject, "new subject");
   assertEquals(amended.body, "new body");
 });
 
-Deno.test("git().commit.amend({ body }) does not update commit summary", async () => {
+Deno.test("git().commit.amend({ body }) does not update commit subject", async () => {
   await using repo = await tempRepository();
   await Deno.writeTextFile(repo.path("file"), "content");
   await repo.index.add("file");
-  await repo.commit.create("summary");
+  await repo.commit.create("subject");
   const amended = await repo.commit.amend({ body: "new body" });
-  assertEquals(amended.summary, "summary");
+  assertEquals(amended.subject, "subject");
   assertEquals(amended.body, "new body");
 });
 
@@ -3194,9 +3194,9 @@ Deno.test("git().commit.amend({ body }) overrides commit trailers", async () => 
   await using repo = await tempRepository();
   await Deno.writeTextFile(repo.path("file"), "content");
   await repo.index.add("file");
-  await repo.commit.create("summary", { trailers: { key: "value" } });
+  await repo.commit.create("subject", { trailers: { key: "value" } });
   const amended = await repo.commit.amend({ body: "new body" });
-  assertEquals(amended.summary, "summary");
+  assertEquals(amended.subject, "subject");
   assertEquals(amended.body, "new body");
   assertEquals(amended.trailers, {});
 });
@@ -3236,34 +3236,34 @@ Deno.test("git().commit.amend({ sign }) cannot use wrong key", async () => {
   );
 });
 
-Deno.test("git().commit.amend({ summary }) changes the commit message", async () => {
+Deno.test("git().commit.amend({ subject }) changes the commit message", async () => {
   await using repo = await tempRepository();
   await Deno.writeTextFile(repo.path("file"), "content");
   await repo.index.add("file");
-  const commit = await repo.commit.create("summary");
-  const amended = await repo.commit.amend({ summary: "new summary" });
-  assertEquals(amended.summary, "new summary");
+  const commit = await repo.commit.create("subject");
+  const amended = await repo.commit.amend({ subject: "new subject" });
+  assertEquals(amended.subject, "new subject");
   assertNotEquals(amended.hash, commit.hash);
 });
 
-Deno.test("git().commit.amend({ summary }) overrides commit body", async () => {
+Deno.test("git().commit.amend({ subject }) overrides commit body", async () => {
   await using repo = await tempRepository();
   await Deno.writeTextFile(repo.path("file"), "content");
   await repo.index.add("file");
-  const original = await repo.commit.create("summary", { body: "body" });
-  const amended = await repo.commit.amend({ summary: "new summary" });
-  assertEquals(amended.summary, "new summary");
+  const original = await repo.commit.create("subject", { body: "body" });
+  const amended = await repo.commit.amend({ subject: "new subject" });
+  assertEquals(amended.subject, "new subject");
   assertEquals(amended.body, undefined);
   assertNotEquals(amended.hash, original.hash);
 });
 
-Deno.test("git().commit.amend({ summary }) rejects empty summary", async () => {
+Deno.test("git().commit.amend({ subject }) rejects empty subject", async () => {
   await using repo = await tempRepository();
   await Deno.writeTextFile(repo.path("file"), "content");
   await repo.index.add("file");
-  await repo.commit.create("summary");
+  await repo.commit.create("subject");
   await assertRejects(
-    () => repo.commit.amend({ summary: "" }),
+    () => repo.commit.amend({ subject: "" }),
     GitError,
     "empty commit message",
   );
@@ -3273,24 +3273,24 @@ Deno.test("git().commit.amend({ trailers }) adds trailers to commit", async () =
   await using repo = await tempRepository();
   await Deno.writeTextFile(repo.path("file"), "content");
   await repo.index.add("file");
-  await repo.commit.create("summary");
+  await repo.commit.create("subject");
   const amended = await repo.commit.amend({
-    summary: "summary",
+    subject: "subject",
     body: "body",
     trailers: { key: "value" },
   });
-  assertEquals(amended.summary, "summary");
+  assertEquals(amended.subject, "subject");
   assertEquals(amended.body, "body");
   assertEquals(amended.trailers, { key: "value" });
 });
 
-Deno.test("git().commit.amend({ trailers }) does not update commit summary or body", async () => {
+Deno.test("git().commit.amend({ trailers }) does not update commit subject or body", async () => {
   await using repo = await tempRepository();
   await Deno.writeTextFile(repo.path("file"), "content");
   await repo.index.add("file");
-  await repo.commit.create("summary", { body: "body" });
+  await repo.commit.create("subject", { body: "body" });
   const amended = await repo.commit.amend({ trailers: { key: "value" } });
-  assertEquals(amended.summary, "summary");
+  assertEquals(amended.subject, "subject");
   assertEquals(amended.body, "body");
   assertEquals(amended.trailers, { key: "value" });
 });
@@ -4524,7 +4524,7 @@ Deno.test("git().tag.list({ sort }) can sort by pre-release version", async () =
   await using repo = await tempRepository({
     config: { versionsort: { suffix: ["-pre", "-beta", "-rc"] } },
   });
-  await repo.commit.create("summary", { allowEmpty: true });
+  await repo.commit.create("subject", { allowEmpty: true });
   const tag100 = await repo.tag.create("v1.0.0");
   const tag200 = await repo.tag.create("v2.0.0");
   const tag200beta = await repo.tag.create("v2.0.0-beta");
@@ -4561,7 +4561,7 @@ Deno.test("git().tag.get() returns tag by object", async () => {
   assertEquals(await repo.tag.get(tag), tag);
 });
 
-Deno.test("git().tag.get() returns undefined for nonexistent tag", async () => {
+Deno.test("git().tag.get() returns undefined for unknown tag", async () => {
   await using repo = await tempRepository();
   await repo.commit.create("commit", { allowEmpty: true });
   assertEquals(await repo.tag.get("unknown"), undefined);
@@ -4721,7 +4721,7 @@ Deno.test("git().tag.delete() can delete tag by name", async () => {
   assertEquals(await repo.tag.list(), []);
 });
 
-Deno.test("git().tag.delete() rejects non-existent tag", async () => {
+Deno.test("git().tag.delete() rejects unknown tag", async () => {
   await using repo = await tempRepository();
   await repo.commit.create("commit", { allowEmpty: true });
   await assertRejects(

--- a/core/git/testing.test.ts
+++ b/core/git/testing.test.ts
@@ -12,7 +12,7 @@ Deno.test("testCommit() creates a commit with default data", () => {
   const commit = testCommit();
   assertGreater(commit.hash.length, 0);
   assertGreater(commit.short.length, 0);
-  assertGreater(commit.summary.length, 0);
+  assertGreater(commit.subject.length, 0);
   assertGreater(commit.body?.length, 0);
   assertExists(commit.trailers);
   assertGreater(commit.author.name.length, 0);
@@ -23,14 +23,14 @@ Deno.test("testCommit() creates a commit with default data", () => {
 
 Deno.test("testCommit() creates a commit with custom data", () => {
   const commit = testCommit({
-    summary: "custom-summary",
+    subject: "custom-subject",
     body: "custom-body",
     author: {
       name: "custom-author-name",
       email: "custom-author-email",
     },
   });
-  assertEquals(commit.summary, "custom-summary");
+  assertEquals(commit.subject, "custom-subject");
   assertEquals(commit.body, "custom-body");
   assertEquals(commit.author.name, "custom-author-name");
   assertEquals(commit.author.email, "custom-author-email");

--- a/core/git/testing.ts
+++ b/core/git/testing.ts
@@ -6,8 +6,8 @@
  * import { tempRepository, testCommit } from "@roka/git/testing";
  *
  * await using repo = await tempRepository();
- * const commit = testCommit({ summary: "feat(cli): add command" });
- * await repo.commit.create(commit.summary, {
+ * const commit = testCommit({ subject: "feat(cli): add command" });
+ * await repo.commit.create(commit.subject, {
  *   author: commit.author,
  *   allowEmpty: true,
  * });
@@ -21,20 +21,20 @@ import { type Commit, type Config, type Git, git } from "./git.ts";
 /**
  * Creates a commit with fake data.
  *
- * @example Create a commit with a summary.
+ * @example Create a commit with a subject.
  * ```ts
  * import { testCommit } from "@roka/git/testing";
  * import { assertEquals } from "@std/assert";
  *
- * const commit = testCommit({ summary: "feat(cli): add command" });
- * assertEquals(commit.summary, "feat(cli): add command");
+ * const commit = testCommit({ subject: "feat(cli): add command" });
+ * assertEquals(commit.subject, "feat(cli): add command");
  * ```
  */
 export function testCommit(data?: Partial<Commit>): Commit {
   return {
     hash: "hash",
     short: "short",
-    summary: "summary",
+    subject: "subject",
     body: "body",
     trailers: {},
     author: { name: "author-name", email: "author-email" },

--- a/core/github/github.ts
+++ b/core/github/github.ts
@@ -348,7 +348,7 @@ function repository(
         const commit = !options?.title
           ? (await git.commit.log({ range: { from: base } })).pop()
           : undefined;
-        const title = options?.title ?? commit?.summary;
+        const title = options?.title ?? commit?.subject;
         const body = options?.body ?? commit?.body;
         const response = await api.rest.pulls.create({
           owner,

--- a/tool/forge/bump.test.ts
+++ b/tool/forge/bump.test.ts
@@ -12,8 +12,8 @@ Deno.test("bump() minor updates released package", async () => {
   await using pkg = await tempPackage({
     config: { name: "@scope/name", version: `1.2.3` },
     commits: [
-      { summary: "initial", tags: ["name@1.2.3"] },
-      { summary: "feat: new feature" },
+      { subject: "initial", tags: ["name@1.2.3"] },
+      { subject: "feat: new feature" },
     ],
   });
   const repo = git({ cwd: pkg.root });
@@ -24,13 +24,13 @@ Deno.test("bump() minor updates released package", async () => {
   const updated = await packageInfo({ directory: pkg.directory });
   assertEquals(updated.config, pkg.config);
   const head = await repo.commit.head();
-  assertEquals(head.summary, "feat: new feature");
+  assertEquals(head.subject, "feat: new feature");
 });
 
 Deno.test("bump() minor updates unreleased package", async () => {
   await using pkg = await tempPackage({
     config: { name: "@scope/name" },
-    commits: [{ summary: "feat: new feature" }],
+    commits: [{ subject: "feat: new feature" }],
   });
   const repo = git({ cwd: pkg.root });
   const commit = await repo.commit.head();
@@ -41,7 +41,7 @@ Deno.test("bump() minor updates unreleased package", async () => {
 Deno.test("bump() patch updates unreleased package", async () => {
   await using pkg = await tempPackage({
     config: { name: "@scope/name" },
-    commits: [{ summary: "fix: bug fix" }],
+    commits: [{ subject: "fix: bug fix" }],
   });
   const repo = git({ cwd: pkg.root });
   const commit = await repo.commit.head();
@@ -52,7 +52,7 @@ Deno.test("bump() patch updates unreleased package", async () => {
 Deno.test("bump() patch updates package with unstable changes", async () => {
   await using pkg = await tempPackage({
     config: { name: "@scope/name" },
-    commits: [{ summary: "feat(unstable): new unstable feature" }],
+    commits: [{ subject: "feat(unstable): new unstable feature" }],
   });
   const repo = git({ cwd: pkg.root });
   const commit = await repo.commit.head();
@@ -64,8 +64,8 @@ Deno.test("bump() does not mutate package on failure", async () => {
   await using pkg = await tempPackage({
     config: { name: "@scope/name", version: "0.0.1" },
     commits: [
-      { summary: "initial", tags: ["name@0.0.1"] },
-      { summary: "feat: new feature" },
+      { subject: "initial", tags: ["name@0.0.1"] },
+      { subject: "feat: new feature" },
     ],
   });
   await Deno.remove(join(pkg.directory, "deno.json"));
@@ -84,13 +84,13 @@ Deno.test("bump() updates workspace", async () => {
     ],
     commits: [
       {
-        summary: "initial",
+        subject: "initial",
         tags: ["name1@1.2.3", "name2@1.2.3", "name3@1.2.3", "name4@1.2.3"],
       },
-      { summary: "fix(name1): fix bug (#1)" },
-      { summary: "feat(name2): new feature (#2)" },
-      { summary: "feat(name3)!: breaking changes (#3)" },
-      { summary: "feat(name4/unstable): new unstable feature (#5)" },
+      { subject: "fix(name1): fix bug (#1)" },
+      { subject: "feat(name2): new feature (#2)" },
+      { subject: "feat(name3)!: breaking changes (#3)" },
+      { subject: "feat(name4/unstable): new unstable feature (#5)" },
     ],
   });
   await bump(packages, { release: true });
@@ -106,8 +106,8 @@ Deno.test("bump({ release }) bumps to release version", async () => {
   await using pkg = await tempPackage({
     config: { name: "@scope/name", version: `1.2.3` },
     commits: [
-      { summary: "initial", tags: ["name@1.2.3"] },
-      { summary: "feat: new feature" },
+      { subject: "initial", tags: ["name@1.2.3"] },
+      { subject: "feat: new feature" },
     ],
   });
   await bump([pkg], { release: true });
@@ -121,13 +121,13 @@ Deno.test("bump({ changelog }) creates a changelog file", async () => {
       { name: "@scope/name2" },
     ],
     commits: [
-      { summary: "feat(name1): introduce name1 (#1)" },
-      { summary: "feat(name2): introduce name2 (#2)" },
-      { summary: "fix(name1): fix bug (#3)" },
+      { subject: "feat(name1): introduce name1 (#1)" },
+      { subject: "feat(name2): introduce name2 (#2)" },
+      { subject: "fix(name1): fix bug (#3)" },
       {
-        summary: [
+        subject: [
           "fix(name2): fix bug, but for some reason use a very",
-          "very long summary that doesn't fit in one line (#4)",
+          "very long subject that doesn't fit in one line (#4)",
         ].join(" "),
       },
     ],
@@ -147,7 +147,7 @@ Deno.test("bump({ changelog }) creates a changelog file", async () => {
       "## name2@0.1.0",
       "",
       "- feat(name2): introduce name2 (#2)",
-      "- fix(name2): fix bug, but for some reason use a very very long summary that",
+      "- fix(name2): fix bug, but for some reason use a very very long subject that",
       "  doesn't fit in one line (#4)",
       "",
     ].join("\n"),
@@ -157,7 +157,7 @@ Deno.test("bump({ changelog }) creates a changelog file", async () => {
 Deno.test("bump({ changelog }) can update a changelog file", async () => {
   await using pkg = await tempPackage({
     config: { name: "@scope/name" },
-    commits: [{ summary: "fix: bug (#42)" }],
+    commits: [{ subject: "fix: bug (#42)" }],
   });
   const changelog = join(pkg.directory, "changelog.txt");
   await Deno.writeTextFile(
@@ -191,9 +191,9 @@ Deno.test("bump({ pr }) creates a pull request", async () => {
     config: { name: "@scope/name", version: "1.2.3" },
     repo: { clone: remote },
     commits: [
-      { summary: "initial", tags: ["name@1.2.3"] },
-      { summary: "feat: new feature (#42)" },
-      { summary: "fix: force pushed" },
+      { subject: "initial", tags: ["name@1.2.3"] },
+      { subject: "feat: new feature (#42)" },
+      { subject: "fix: force pushed" },
     ],
   });
   const repo = fakeRepository({ git: git({ cwd: pkg.root }) });
@@ -227,7 +227,7 @@ Deno.test("bump({ pr }) creates a pull request", async () => {
   const commit = await remote.commit.head();
   assertEquals(commit.author?.name, "bump-name");
   assertEquals(commit.author?.email, "bump-email");
-  assertEquals(commit.summary, "chore: bump name to 1.3.0");
+  assertEquals(commit.subject, "chore: bump name to 1.3.0");
   assertEquals(
     commit.body,
     [
@@ -245,8 +245,8 @@ Deno.test("bump({ pr }) can update a pull request", async () => {
     config: { name: "@scope/name", version: "1.2.3" },
     repo: { clone: remote },
     commits: [
-      { summary: "initial", tags: ["name@1.2.3"] },
-      { summary: "feat: new feature (#42)" },
+      { subject: "initial", tags: ["name@1.2.3"] },
+      { subject: "feat: new feature (#42)" },
     ],
   });
   const repo = fakeRepository({ git: git({ cwd: pkg.root }) });
@@ -283,7 +283,7 @@ Deno.test("bump({ pr }) creates a pull request against the current branch", asyn
   await using pkg = await tempPackage({
     config: { name: "@scope/name" },
     repo: { clone: remote },
-    commits: [{ summary: "feat: new feature" }],
+    commits: [{ subject: "feat: new feature" }],
   });
   const repo = fakeRepository({ git: git({ cwd: pkg.root }) });
   const pr = await bump([pkg], {
@@ -300,7 +300,7 @@ Deno.test("bump({ pr }) creates a pull request against the current branch", asyn
 Deno.test("bump({ pr }) rejects pull request without update", async () => {
   await using pkg = await tempPackage({
     config: { name: "@scope/name", version: "0.1.0" },
-    commits: [{ summary: "feat: new feature", tags: ["name@0.1.0"] }],
+    commits: [{ subject: "feat: new feature", tags: ["name@0.1.0"] }],
   });
   await assertRejects(() => bump([pkg], { pr: true }), PackageError);
 });
@@ -311,9 +311,9 @@ Deno.test("bump({ pr }) rejects if pull request branch exists locally", async ()
     config: { name: "@scope/name", version: "1.2.3" },
     repo: { clone: remote },
     commits: [
-      { summary: "initial", tags: ["name@1.2.3"] },
-      { summary: "feat: new feature (#42)" },
-      { summary: "fix: force pushed" },
+      { subject: "initial", tags: ["name@1.2.3"] },
+      { subject: "feat: new feature (#42)" },
+      { subject: "fix: force pushed" },
     ],
   });
   const repo = fakeRepository({ git: git({ cwd: pkg.root }) });
@@ -327,7 +327,7 @@ Deno.test("bump({ draft }) can create a draft pull request", async () => {
   await using pkg = await tempPackage({
     config: { name: "@scope/name" },
     repo: { clone: remote },
-    commits: [{ summary: "feat: new feature" }],
+    commits: [{ subject: "feat: new feature" }],
   });
   const repo = fakeRepository({ git: git({ cwd: pkg.root }) });
   const pr = await bump([pkg], {

--- a/tool/forge/bump.ts
+++ b/tool/forge/bump.ts
@@ -85,7 +85,7 @@ export interface BumpOptions {
    */
   draft?: boolean;
   /**
-   * Use emoji in commit summaries.
+   * Use emoji in commit subjects.
    * @default {false}
    */
   emoji?: boolean;

--- a/tool/forge/changelog.test.ts
+++ b/tool/forge/changelog.test.ts
@@ -4,10 +4,10 @@ import { changelog } from "./changelog.ts";
 
 Deno.test("changelog() generates Markdown changelog", () => {
   const commits = [
-    testCommit({ summary: "feat(name): introduce" }),
-    testCommit({ summary: "build(name)!: breaking" }),
-    testCommit({ summary: "fix: fix code" }),
-    testCommit({ summary: "no type" }),
+    testCommit({ subject: "feat(name): introduce" }),
+    testCommit({ subject: "build(name)!: breaking" }),
+    testCommit({ subject: "fix: fix code" }),
+    testCommit({ subject: "no type" }),
   ];
   assertEquals(
     changelog(commits),
@@ -23,8 +23,8 @@ Deno.test("changelog() generates Markdown changelog", () => {
 
 Deno.test("changelog() allows custom content", () => {
   const commits = [
-    testCommit({ summary: "feat: introduce" }),
-    testCommit({ summary: "fix: fix code" }),
+    testCommit({ subject: "feat: introduce" }),
+    testCommit({ subject: "fix: fix code" }),
   ];
   assertEquals(
     changelog(commits, {
@@ -50,8 +50,8 @@ Deno.test("changelog() allows custom content", () => {
 
 Deno.test("changelog() allows custom Markdown", () => {
   const commits = [
-    testCommit({ summary: "feat: introduce" }),
-    testCommit({ summary: "fix: fix code" }),
+    testCommit({ subject: "feat: introduce" }),
+    testCommit({ subject: "fix: fix code" }),
   ];
   assertEquals(
     changelog(commits, {
@@ -78,26 +78,26 @@ Deno.test("changelog() allows custom Markdown", () => {
 
 Deno.test("changelog() can sort commits by importance", () => {
   const commits = [
-    testCommit({ summary: "style!: breaking-style-1" }),
-    testCommit({ summary: "build: build" }),
-    testCommit({ summary: "build!: breaking-build" }),
-    testCommit({ summary: "chore: chore" }),
-    testCommit({ summary: "ci: ci" }),
-    testCommit({ summary: "docs: docs" }),
-    testCommit({ summary: "fix: fix" }),
-    testCommit({ summary: "fix!: breaking-fix" }),
-    testCommit({ summary: "perf: perf-1" }),
-    testCommit({ summary: "refactor: refactor" }),
-    testCommit({ summary: "revert: revert" }),
-    testCommit({ summary: "style: style" }),
-    testCommit({ summary: "style!: breaking-style-2" }),
-    testCommit({ summary: "test: test" }),
-    testCommit({ summary: "perf: perf-2" }),
-    testCommit({ summary: "unknown: unknown" }),
-    testCommit({ summary: "no type" }),
-    testCommit({ summary: "feat: feat-1" }),
-    testCommit({ summary: "feat: feat-2" }),
-    testCommit({ summary: "feat!: breaking-feat" }),
+    testCommit({ subject: "style!: breaking-style-1" }),
+    testCommit({ subject: "build: build" }),
+    testCommit({ subject: "build!: breaking-build" }),
+    testCommit({ subject: "chore: chore" }),
+    testCommit({ subject: "ci: ci" }),
+    testCommit({ subject: "docs: docs" }),
+    testCommit({ subject: "fix: fix" }),
+    testCommit({ subject: "fix!: breaking-fix" }),
+    testCommit({ subject: "perf: perf-1" }),
+    testCommit({ subject: "refactor: refactor" }),
+    testCommit({ subject: "revert: revert" }),
+    testCommit({ subject: "style: style" }),
+    testCommit({ subject: "style!: breaking-style-2" }),
+    testCommit({ subject: "test: test" }),
+    testCommit({ subject: "perf: perf-2" }),
+    testCommit({ subject: "unknown: unknown" }),
+    testCommit({ subject: "no type" }),
+    testCommit({ subject: "feat: feat-1" }),
+    testCommit({ subject: "feat: feat-2" }),
+    testCommit({ subject: "feat!: breaking-feat" }),
   ];
   assertEquals(
     changelog(commits, {
@@ -131,20 +131,20 @@ Deno.test("changelog() can sort commits by importance", () => {
 
 Deno.test("changelog() generates frivolous changelog with emojis", () => {
   const commits = [
-    testCommit({ summary: "build(name)!: breaking" }),
-    testCommit({ summary: "build: build" }),
-    testCommit({ summary: "chore(name): chore" }),
-    testCommit({ summary: "ci: ci" }),
-    testCommit({ summary: "docs(name): docs" }),
-    testCommit({ summary: "feat: feat" }),
-    testCommit({ summary: "fix(module/submodule): fix" }),
-    testCommit({ summary: "perf: perf" }),
-    testCommit({ summary: "refactor(name/unstable): refactor" }),
-    testCommit({ summary: "revert: revert" }),
-    testCommit({ summary: "style(name): style" }),
-    testCommit({ summary: "test: test" }),
-    testCommit({ summary: "unknown(name): unknown" }),
-    testCommit({ summary: "no type" }),
+    testCommit({ subject: "build(name)!: breaking" }),
+    testCommit({ subject: "build: build" }),
+    testCommit({ subject: "chore(name): chore" }),
+    testCommit({ subject: "ci: ci" }),
+    testCommit({ subject: "docs(name): docs" }),
+    testCommit({ subject: "feat: feat" }),
+    testCommit({ subject: "fix(module/submodule): fix" }),
+    testCommit({ subject: "perf: perf" }),
+    testCommit({ subject: "refactor(name/unstable): refactor" }),
+    testCommit({ subject: "revert: revert" }),
+    testCommit({ subject: "style(name): style" }),
+    testCommit({ subject: "test: test" }),
+    testCommit({ subject: "unknown(name): unknown" }),
+    testCommit({ subject: "no type" }),
   ];
   assertEquals(
     changelog(commits, {
@@ -173,9 +173,9 @@ Deno.test("changelog() generates frivolous changelog with emojis", () => {
 
 Deno.test("changelog() generates commit hashes", () => {
   const commits = [
-    testCommit({ summary: "fix code (#1)" }),
-    testCommit({ summary: "not a number (#this is not)", short: "short-1" }),
-    testCommit({ summary: "no number", short: "short-2" }),
+    testCommit({ subject: "fix code (#1)" }),
+    testCommit({ subject: "not a number (#this is not)", short: "short-1" }),
+    testCommit({ subject: "no number", short: "short-2" }),
   ];
   assertEquals(
     changelog(commits, { commit: { hash: true } }),
@@ -190,11 +190,11 @@ Deno.test("changelog() generates commit hashes", () => {
 
 Deno.test("changelog() generates pull request numbers", () => {
   const commits = [
-    testCommit({ summary: "feat(name): introduce (#3)" }),
-    testCommit({ summary: "build(name/submodule)!: breaking (#2)" }),
-    testCommit({ summary: "fix: fix code (#1)" }),
-    testCommit({ summary: "fix: not a number (#this is not)" }),
-    testCommit({ summary: "no number" }),
+    testCommit({ subject: "feat(name): introduce (#3)" }),
+    testCommit({ subject: "build(name/submodule)!: breaking (#2)" }),
+    testCommit({ subject: "fix: fix code (#1)" }),
+    testCommit({ subject: "fix: not a number (#this is not)" }),
+    testCommit({ subject: "no number" }),
   ];
   assertEquals(
     changelog(commits, { commit: { github: true } }),
@@ -211,11 +211,11 @@ Deno.test("changelog() generates pull request numbers", () => {
 
 Deno.test("changelog() generates pull request numbers with emojis", () => {
   const commits = [
-    testCommit({ summary: "feat(name): introduce (#3)" }),
-    testCommit({ summary: "build(name/submodule)!: breaking (#2)" }),
-    testCommit({ summary: "fix: fix code (#1)" }),
-    testCommit({ summary: "fix: not a number (#this is not)" }),
-    testCommit({ summary: "no number" }),
+    testCommit({ subject: "feat(name): introduce (#3)" }),
+    testCommit({ subject: "build(name/submodule)!: breaking (#2)" }),
+    testCommit({ subject: "fix: fix code (#1)" }),
+    testCommit({ subject: "fix: not a number (#this is not)" }),
+    testCommit({ subject: "no number" }),
   ];
   assertEquals(
     changelog(commits, { commit: { emoji: true, github: true } }),

--- a/tool/forge/changelog.ts
+++ b/tool/forge/changelog.ts
@@ -50,12 +50,12 @@ export interface ChangelogOptions {
      */
     sort?: "importance";
     /**
-     * Use emoji in commit summaries.
+     * Use emoji in commit subjects.
      * @default {false}
      */
     emoji?: boolean;
     /**
-     * Include short commit hash in commit summaries, when a pull request number
+     * Include short commit hash in commit subjects, when a pull request number
      * is not available.
      *
      * This is useful for generating links to commits that were not merged with a
@@ -65,7 +65,7 @@ export interface ChangelogOptions {
      */
     hash?: boolean;
     /**
-     * List only pull request numbers as commit summaries.
+     * List only pull request numbers as commit subjects.
      *
      * This provides a nicely formatted changelog for GitHub pull requests, and
      * avoids listing commit titles twice.
@@ -142,7 +142,7 @@ export function changelog(
   if (options?.commit?.sort === "importance") log = sorted(log, byImportance);
   const blocks = [
     ...title ? [`${markdown.heading}${title}`] : [],
-    log.map((c) => `${markdown.bullet}${summary(c, options)}`).join("\n") ?? [],
+    log.map((c) => `${markdown.bullet}${subject(c, options)}`).join("\n") ?? [],
     footer,
   ].flat();
   return `${blocks.join("\n\n")}\n`;
@@ -171,21 +171,21 @@ function byImportance(a: ConventionalCommit, b: ConventionalCommit) {
   return 0;
 }
 
-function summary(
+function subject(
   commit: ConventionalCommit,
   options: ChangelogOptions | undefined,
 ): string {
   const prPattern = /^.*\((#\d+)\)$/;
-  let summary = options?.commit?.emoji ? commit.description : commit.summary;
-  if (options?.commit?.hash && !summary.match(prPattern)) {
-    summary = `${summary} (${commit.short})`;
+  let subject = options?.commit?.emoji ? commit.description : commit.subject;
+  if (options?.commit?.hash && !subject.match(prPattern)) {
+    subject = `${subject} (${commit.short})`;
   }
-  if (options?.commit?.github) summary = summary.replace(prPattern, "$1");
-  if (options?.commit?.emoji) summary = emoji(commit, summary);
-  return summary;
+  if (options?.commit?.github) subject = subject.replace(prPattern, "$1");
+  if (options?.commit?.emoji) subject = emoji(commit, subject);
+  return subject;
 }
 
-function emoji(commit: ConventionalCommit, summary: string): string {
+function emoji(commit: ConventionalCommit, description: string): string {
   const emojis: Record<string, string> = {
     build: "🔧",
     chore: "🧹",
@@ -202,7 +202,7 @@ function emoji(commit: ConventionalCommit, summary: string): string {
   };
   return [
     emojis[commit.type ?? "unknown"] ?? emojis["unknown"],
-    summary,
+    description,
     ...commit.breaking ? ["💥"] : [],
   ].join(" ");
 }

--- a/tool/forge/forge.test.ts
+++ b/tool/forge/forge.test.ts
@@ -6,9 +6,9 @@ import { assertExists } from "@std/assert";
 import { common, join } from "@std/path";
 import { assertSnapshot } from "@std/testing/snapshot";
 import { forge } from "./forge.ts";
-import { tempWorkspace } from "./testing.ts";
+import { tempWorkspace, type TempWorkspaceOptions } from "./testing.ts";
 
-const WORKSPACE = {
+const WORKSPACE: TempWorkspaceOptions = {
   configs: [
     {
       name: "@scope/name1",
@@ -38,14 +38,14 @@ const WORKSPACE = {
     },
   ],
   commits: [
-    { summary: "initial", tags: ["name1@1.0.0-pre.1", "name4@4.0.0"] },
-    { summary: "feat(name2): name2", tags: ["name2@1.0.0"] },
-    { summary: "fix(name1): bug", tags: ["name2@2.0.0"] },
-    { summary: "refactor(name2): rewrite" },
-    { summary: "feat(name2): feature", tags: ["name3@2.0.0"] },
-    { summary: "docs(name3): fix typo" },
-    { summary: "refactor(name4)!: redesign api" },
-    { summary: "style(name5): tabs over spaces" },
+    { subject: "initial", tags: ["name1@1.0.0-pre.1", "name4@4.0.0"] },
+    { subject: "feat(name2): name2", tags: ["name2@1.0.0"] },
+    { subject: "fix(name1): bug", tags: ["name2@2.0.0"] },
+    { subject: "refactor(name2): rewrite" },
+    { subject: "feat(name2): feature", tags: ["name3@2.0.0"] },
+    { subject: "docs(name3): fix typo" },
+    { subject: "refactor(name4)!: redesign api" },
+    { subject: "style(name5): tabs over spaces" },
   ],
 };
 

--- a/tool/forge/forge.ts
+++ b/tool/forge/forge.ts
@@ -81,7 +81,7 @@
  * derived from the last commit that updated the package.
  *
  * If you’re working on just one package, you can skip the scopes altogether.
- * In this case, a commit summary like “_feat: feature_” will also trigger a
+ * In this case, a commit subject like “_feat: feature_” will also trigger a
  * version change. But if you’re in a workspace with multiple packages, the
  * scope is needed to figure out which packages will update.
  *
@@ -422,7 +422,7 @@ function changelogCommand(context: ForgeOptions | undefined) {
     .option("--type=<type:string>", "Commit type.", { collect: true })
     .option("--breaking", "Only breaking changes.")
     .option("--no-breaking", "Skip breaking changes of filtered types.")
-    .option("--emoji", "Use emoji for commit summaries.", { default: false })
+    .option("--emoji", "Use emoji for commit subjects.", { default: false })
     .option("--markdown", "Generate Markdown.", { default: false })
     .action(async (options, ...filters) => {
       const packages = await filter(filters, context);
@@ -555,7 +555,7 @@ function releaseCommand(context: ForgeOptions | undefined) {
     .example("forge release --draft", "Create draft releases for all updates.")
     .arguments("[packages...:file]")
     .option("--draft", "Create a draft release.", { default: false })
-    .option("--emoji", "Use emoji for commit summaries.", { default: false })
+    .option("--emoji", "Use emoji for commit subjects.", { default: false })
     .env(
       "GITHUB_TOKEN=<token:string>",
       "GitHub personal token for GitHub actions.",

--- a/tool/forge/package.test.ts
+++ b/tool/forge/package.test.ts
@@ -68,7 +68,7 @@ Deno.test("packageInfo() rejects invalid version", async () => {
 Deno.test("packageInfo() returns release version at release commit", async () => {
   await using temp = await tempPackage({
     config: { name: "@scope/name", version: "1.2.3" },
-    commits: [{ summary: "initial", tags: ["name@1.2.3"] }],
+    commits: [{ subject: "initial", tags: ["name@1.2.3"] }],
   });
   const directory = temp.directory;
   assertEquals(await packageInfo({ directory }), {
@@ -86,8 +86,8 @@ Deno.test("packageInfo() calculates patch version update", async () => {
   await using temp = await tempPackage({
     config: { name: "@scope/name", version: "1.2.3" },
     commits: [
-      { summary: "initial", tags: ["name@1.2.3"] },
-      { summary: "fix: bug fix" },
+      { subject: "initial", tags: ["name@1.2.3"] },
+      { subject: "fix: bug fix" },
     ],
   });
   const directory = temp.directory;
@@ -104,8 +104,8 @@ Deno.test("packageInfo() calculates minor version update", async () => {
   await using temp = await tempPackage({
     config: { name: "@scope/name", version: "1.2.3" },
     commits: [
-      { summary: "initial", tags: ["name@1.2.3"] },
-      { summary: "feat: new feature" },
+      { subject: "initial", tags: ["name@1.2.3"] },
+      { subject: "feat: new feature" },
     ],
   });
   const directory = temp.directory;
@@ -122,8 +122,8 @@ Deno.test("packageInfo() calculates major version update", async () => {
   await using temp = await tempPackage({
     config: { name: "@scope/name", version: "1.2.3" },
     commits: [
-      { summary: "initial", tags: ["name@1.2.3"] },
-      { summary: "fix!: breaking change" },
+      { subject: "initial", tags: ["name@1.2.3"] },
+      { subject: "fix!: breaking change" },
     ],
   });
   const directory = temp.directory;
@@ -140,8 +140,8 @@ Deno.test("packageInfo() matches all scopes for non-workspace", async () => {
   await using temp = await tempPackage({
     config: { name: "@scope/name" },
     commits: [
-      { summary: "fix(something): done" },
-      { summary: "fix: something else" },
+      { subject: "fix(something): done" },
+      { subject: "fix: something else" },
     ],
   });
   const directory = temp.directory;
@@ -160,8 +160,8 @@ Deno.test("packageInfo() skips change if type is not feat or fix", async () => {
   await using temp = await tempPackage({
     config: { name: "@scope/name" },
     commits: [
-      { summary: "fix: fix bug" },
-      { summary: "style: argue on whitespace" },
+      { subject: "fix: fix bug" },
+      { subject: "style: argue on whitespace" },
     ],
   });
   const directory = temp.directory;
@@ -179,8 +179,8 @@ Deno.test("packageInfo() considers all breaking changes", async () => {
   await using temp = await tempPackage({
     config: { name: "@scope/name" },
     commits: [
-      { summary: "fix: fix bug" },
-      { summary: "style!: api breaking whitespace changes" },
+      { subject: "fix: fix bug" },
+      { subject: "style!: api breaking whitespace changes" },
     ],
   });
   const directory = temp.directory;
@@ -199,9 +199,9 @@ Deno.test("packageInfo() calculates patch version update for unstable changes", 
   await using temp = await tempPackage({
     config: { name: "@scope/name", version: "1.2.3" },
     commits: [
-      { summary: "initial", tags: ["name@1.2.3"] },
-      { summary: "feat(unstable): new unstable feature" },
-      { summary: "fix(unstable): fix unstable feature" },
+      { subject: "initial", tags: ["name@1.2.3"] },
+      { subject: "feat(unstable): new unstable feature" },
+      { subject: "fix(unstable): fix unstable feature" },
     ],
   });
   const directory = temp.directory;
@@ -220,8 +220,8 @@ Deno.test("packageInfo() breaking changes are still breaking for unstable", asyn
   await using temp = await tempPackage({
     config: { name: "@scope/name", version: "1.2.3" },
     commits: [
-      { summary: "initial", tags: ["name@1.2.3"] },
-      { summary: "feat(unstable)!: new unstable feature" },
+      { subject: "initial", tags: ["name@1.2.3"] },
+      { subject: "feat(unstable)!: new unstable feature" },
     ],
   });
   const directory = temp.directory;
@@ -238,11 +238,11 @@ Deno.test("packageInfo() skips over pre-release versions", async () => {
   await using temp = await tempPackage({
     config: { name: "@scope/name", version: "1.2.3" },
     commits: [
-      { summary: "initial", tags: ["name@1.2.3"] },
-      { summary: "feat: new feature" },
-      { summary: "fix: bug fix", tags: ["name@1.3.0-pre.2+fedcba9"] },
-      { summary: "docs: fix typo" },
-      { summary: "feat: another feature" },
+      { subject: "initial", tags: ["name@1.2.3"] },
+      { subject: "feat: new feature" },
+      { subject: "fix: bug fix", tags: ["name@1.3.0-pre.2+fedcba9"] },
+      { subject: "docs: fix typo" },
+      { subject: "feat: another feature" },
     ],
   });
   const directory = temp.directory;
@@ -262,7 +262,7 @@ Deno.test("packageInfo() skips over pre-release versions", async () => {
 Deno.test("packageInfo() uses forced version for unreleased package", async () => {
   await using temp = await tempPackage({
     config: { name: "@scope/name", version: "1.2.3" },
-    commits: [{ summary: "initial" }],
+    commits: [{ subject: "initial" }],
   });
   const directory = temp.directory;
   assertObjectMatch(await packageInfo({ directory }), {
@@ -275,7 +275,7 @@ Deno.test("packageInfo() uses forced version for unreleased package", async () =
 Deno.test("packageInfo() uses forced version for released package", async () => {
   await using temp = await tempPackage({
     config: { name: "@scope/name", version: "1.2.4" },
-    commits: [{ summary: "initial", tags: ["name@1.2.3"] }],
+    commits: [{ subject: "initial", tags: ["name@1.2.3"] }],
   });
   const directory = temp.directory;
   assertObjectMatch(await packageInfo({ directory }), {
@@ -288,7 +288,7 @@ Deno.test("packageInfo() uses forced version for released package", async () => 
 Deno.test("packageInfo() ignores forced lower version", async () => {
   await using temp = await tempPackage({
     config: { name: "@scope/name", version: "1.2.2" },
-    commits: [{ summary: "initial", tags: ["name@1.2.3"] }],
+    commits: [{ subject: "initial", tags: ["name@1.2.3"] }],
   });
   const directory = temp.directory;
   assertObjectMatch(await packageInfo({ directory }), {
@@ -409,10 +409,10 @@ Deno.test("workspace() matches commit scope", async () => {
       { name: "pkg3" },
     ],
     commits: [
-      { summary: "initial" },
-      { summary: "fix(pkg1): fix" },
-      { summary: "fix(pkg2/submodule): fix" },
-      { summary: "fix(pkg3/dir/submodule): fix" },
+      { subject: "initial" },
+      { subject: "fix(pkg1): fix" },
+      { subject: "fix(pkg2/submodule): fix" },
+      { subject: "fix(pkg3/dir/submodule): fix" },
     ],
   });
   const [pkg1, pkg2, pkg3] = temp;
@@ -450,10 +450,10 @@ Deno.test("workspace() considers unstable changes", async () => {
       { name: "pkg2", version: "1.2.3" },
     ],
     commits: [
-      { summary: "initial", tags: ["pkg1@1.2.3", "pkg2@1.2.3", "pkg3@1.2.3"] },
-      { summary: "feat(pkg1/dir/unstable): feat" },
-      { summary: "feat(pkg2): feat" },
-      { summary: "fix(pkg2/unstable): fix" },
+      { subject: "initial", tags: ["pkg1@1.2.3", "pkg2@1.2.3", "pkg3@1.2.3"] },
+      { subject: "feat(pkg1/dir/unstable): feat" },
+      { subject: "feat(pkg2): feat" },
+      { subject: "fix(pkg2/unstable): fix" },
     ],
   });
   const [pkg1, pkg2] = temp;
@@ -509,9 +509,9 @@ Deno.test("releases() returns releases for a package", async () => {
   await using pkg = await tempPackage({
     config: { name: "@scope/name", version: "1.2.3" },
     commits: [
-      { summary: "first", tags: ["name@1.2.0", "name@1.2.1"] },
-      { summary: "second", tags: ["name@1.2.2"] },
-      { summary: "third", tags: ["name@1.2.3"] },
+      { subject: "first", tags: ["name@1.2.0", "name@1.2.1"] },
+      { subject: "second", tags: ["name@1.2.2"] },
+      { subject: "third", tags: ["name@1.2.3"] },
     ],
   });
   assertEquals(await releases(pkg), [
@@ -526,8 +526,8 @@ Deno.test("releases() ignores unknown tag format", async () => {
   await using pkg = await tempPackage({
     config: { name: "@scope/name" },
     commits: [
-      { summary: "first", tags: ["beta"] },
-      { summary: "second", tags: ["1.2.3"] },
+      { subject: "first", tags: ["beta"] },
+      { subject: "second", tags: ["1.2.3"] },
     ],
   });
   assertEquals(await releases(pkg), []);
@@ -549,9 +549,9 @@ Deno.test("releases({ prerelease }) include pre-releases", async () => {
   await using pkg = await tempPackage({
     config: { name: "@scope/name" },
     commits: [
-      { summary: "1.2.3", tags: ["name@1.2.3"] },
-      { summary: "2.0.0-pre", tags: ["name@2.0.0-pre.42+fedcba9"] },
-      { summary: "2.0.0", tags: ["name@2.0.0"] },
+      { subject: "1.2.3", tags: ["name@1.2.3"] },
+      { subject: "2.0.0-pre", tags: ["name@2.0.0-pre.42+fedcba9"] },
+      { subject: "2.0.0", tags: ["name@2.0.0"] },
     ],
   });
   assertEquals(await releases(pkg), [
@@ -572,9 +572,9 @@ Deno.test("commits() returns all history", async () => {
   await using pkg = await tempPackage({
     config: { name: "@scope/name" },
     commits: [
-      { summary: "feat: new feature" },
-      { summary: "fix!: fix bug", tags: ["name@1.2.3"] },
-      { summary: "docs: add docs" },
+      { subject: "feat: new feature" },
+      { subject: "fix!: fix bug", tags: ["name@1.2.3"] },
+      { subject: "docs: add docs" },
     ],
   });
   const [docs, fix, feat] = await git({ cwd: pkg.root }).commit.log();
@@ -594,9 +594,9 @@ Deno.test("commits() enforces scope for workspace members", async () => {
       { name: "@scope/name2" },
     ],
     commits: [
-      { summary: "feat: new feature" },
-      { summary: "fix(name1)!: fix bug" },
-      { summary: "docs(name2): add docs" },
+      { subject: "feat: new feature" },
+      { subject: "fix(name1)!: fix bug" },
+      { subject: "docs(name2): add docs" },
     ],
   });
   assertExists(pkg1);
@@ -612,9 +612,9 @@ Deno.test("commits({ range }) returns from a range", async () => {
   await using pkg = await tempPackage({
     config: { name: "@scope/name" },
     commits: [
-      { summary: "feat: new feature" },
-      { summary: "fix!: fix bug", tags: ["name@1.2.3"] },
-      { summary: "docs: add docs" },
+      { subject: "feat: new feature" },
+      { subject: "fix!: fix bug", tags: ["name@1.2.3"] },
+      { subject: "docs: add docs" },
     ],
   });
   assertExists(pkg.latest);
@@ -631,9 +631,9 @@ Deno.test("commits({ type }) filters by type", async () => {
   await using pkg = await tempPackage({
     config: { name: "@scope/name" },
     commits: [
-      { summary: "feat: new feature" },
-      { summary: "fix!: fix bug" },
-      { summary: "docs: add docs" },
+      { subject: "feat: new feature" },
+      { subject: "fix!: fix bug" },
+      { subject: "docs: add docs" },
     ],
   });
   const [_, fix, feat] = await git({ cwd: pkg.root }).commit.log();
@@ -649,9 +649,9 @@ Deno.test("commits({ type }) always includes breaking changes", async () => {
   await using pkg = await tempPackage({
     config: { name: "@scope/name" },
     commits: [
-      { summary: "feat: new feature" },
-      { summary: "fix!: fix bug" },
-      { summary: "docs: add docs" },
+      { subject: "feat: new feature" },
+      { subject: "fix!: fix bug" },
+      { subject: "docs: add docs" },
     ],
   });
   const [docs, fix] = await git({ cwd: pkg.root }).commit.log();
@@ -667,9 +667,9 @@ Deno.test("commits({ breaking }) can filter breaking changes", async () => {
   await using pkg = await tempPackage({
     config: { name: "@scope/name" },
     commits: [
-      { summary: "feat: new feature" },
-      { summary: "fix!: fix bug" },
-      { summary: "docs: add docs" },
+      { subject: "feat: new feature" },
+      { subject: "fix!: fix bug" },
+      { subject: "docs: add docs" },
     ],
   });
   const [_, fix] = await git({ cwd: pkg.root }).commit.log();
@@ -684,9 +684,9 @@ Deno.test("commits({ breaking }) can filter non-breaking changes", async () => {
   await using pkg = await tempPackage({
     config: { name: "@scope/name" },
     commits: [
-      { summary: "feat: new feature" },
-      { summary: "fix!: fix bug" },
-      { summary: "docs: add docs" },
+      { subject: "feat: new feature" },
+      { subject: "fix!: fix bug" },
+      { subject: "docs: add docs" },
     ],
   });
   const [docs] = await git({ cwd: pkg.root }).commit.log();

--- a/tool/forge/package.ts
+++ b/tool/forge/package.ts
@@ -38,7 +38,7 @@
  * ```
  *
  * Commits are only attributed to a workspace member if they explicitly list
- * the package name. For example, a commit with a summary of "_feat: new_" will
+ * the package name. For example, a commit with a subject of "_feat: new_" will
  * not be in included in a workspace package changelog, but "_feat(pkg): new_"
  * will be. However, both will be attributed to a simple (non-workspace)
  * package.

--- a/tool/forge/release.test.ts
+++ b/tool/forge/release.test.ts
@@ -10,7 +10,7 @@ import { tempPackage, unstableTestImports } from "./testing.ts";
 Deno.test("release() rejects package without version", async () => {
   await using pkg = await tempPackage({
     config: { name: "@scope/name" },
-    commits: [{ summary: "feat: new feature" }],
+    commits: [{ subject: "feat: new feature" }],
   });
   const repo = fakeRepository({ git: git({ cwd: pkg.root }) });
   await assertRejects(() => release(pkg, { repo }), PackageError);
@@ -19,7 +19,7 @@ Deno.test("release() rejects package without version", async () => {
 Deno.test("release() rejects version downgrade", async () => {
   await using pkg = await tempPackage({
     config: { name: "@scope/name", version: "0.1.0" },
-    commits: [{ summary: "feat: new feature", tags: ["name@0.1.1"] }],
+    commits: [{ subject: "feat: new feature", tags: ["name@0.1.1"] }],
   });
   const repo = fakeRepository({ git: git({ cwd: pkg.root }) });
   await assertRejects(() => release(pkg, { repo }), PackageError);
@@ -28,7 +28,7 @@ Deno.test("release() rejects version downgrade", async () => {
 Deno.test("release() rejects no change", async () => {
   await using pkg = await tempPackage({
     config: { name: "@scope/name", version: "0.1.0" },
-    commits: [{ summary: "feat: new feature", tags: ["name@0.1.0"] }],
+    commits: [{ subject: "feat: new feature", tags: ["name@0.1.0"] }],
   });
   const repo = fakeRepository({ git: git({ cwd: pkg.root }) });
   await assertRejects(() => release(pkg, { repo }), PackageError);
@@ -37,7 +37,7 @@ Deno.test("release() rejects no change", async () => {
 Deno.test("release() rejects 0.0.0", async () => {
   await using pkg = await tempPackage({
     config: { name: "@scope/name", version: "0.0.0" },
-    commits: [{ summary: "feat: new feature" }],
+    commits: [{ subject: "feat: new feature" }],
   });
   const repo = fakeRepository({ git: git({ cwd: pkg.root }) });
   await assertRejects(() => release(pkg, { repo }), PackageError);
@@ -47,8 +47,8 @@ Deno.test("release() creates initial release", async () => {
   await using pkg = await tempPackage({
     config: { name: "@scope/name", version: "0.1.0" },
     commits: [
-      { summary: "fix: bug fix (#2)" },
-      { summary: "feat: new feature (#1)" },
+      { subject: "fix: bug fix (#2)" },
+      { subject: "feat: new feature (#1)" },
     ],
   });
   const repo = fakeRepository({ url: "url", git: git({ cwd: pkg.root }) });
@@ -78,8 +78,8 @@ Deno.test("release() creates update release", async () => {
   await using pkg = await tempPackage({
     config: { name: "@scope/name", version: "1.3.0" },
     commits: [
-      { summary: "initial", tags: ["name@1.2.3"] },
-      { summary: "feat: new feature (#1)" },
+      { subject: "initial", tags: ["name@1.2.3"] },
+      { subject: "feat: new feature (#1)" },
     ],
   });
   const repo = fakeRepository({ url: "url", git: git({ cwd: pkg.root }) });
@@ -106,8 +106,8 @@ Deno.test("release() can create a pre-release", async () => {
   await using pkg = await tempPackage({
     config: { name: "@scope/name", version: `1.3.0-pre.1+fedcba9` },
     commits: [
-      { summary: "initial", tags: ["name@1.2.3"] },
-      { summary: "feat: new feature" },
+      { subject: "initial", tags: ["name@1.2.3"] },
+      { subject: "feat: new feature" },
     ],
   });
   const repo = fakeRepository({ git: git({ cwd: pkg.root }) });
@@ -122,8 +122,8 @@ Deno.test("release() can update an existing release", async () => {
   await using pkg = await tempPackage({
     config: { name: "@scope/name", version: `1.3.0` },
     commits: [
-      { summary: "initial", tags: ["name@1.2.3"] },
-      { summary: "feat: new feature (#1)" },
+      { subject: "initial", tags: ["name@1.2.3"] },
+      { subject: "feat: new feature (#1)" },
     ],
   });
   const repo = fakeRepository({ url: "url", git: git({ cwd: pkg.root }) });
@@ -187,8 +187,8 @@ Deno.test("release({ draft }) creates draft release", async () => {
   await using pkg = await tempPackage({
     config: { name: "@scope/name", version: "1.3.0" },
     commits: [
-      { summary: "initial", tags: ["name@1.2.3"] },
-      { summary: "feat: new feature" },
+      { subject: "initial", tags: ["name@1.2.3"] },
+      { subject: "feat: new feature" },
     ],
   });
   const repo = fakeRepository({ git: git({ cwd: pkg.root }) });

--- a/tool/forge/release.ts
+++ b/tool/forge/release.ts
@@ -49,7 +49,7 @@ export interface ReleaseOptions {
   repo?: Repository;
   /** Create a draft release. */
   draft?: boolean;
-  /** Use emoji in commit summaries. */
+  /** Use emoji in commit subjects. */
   emoji?: boolean;
 }
 

--- a/tool/forge/testing.test.ts
+++ b/tool/forge/testing.test.ts
@@ -29,8 +29,8 @@ Deno.test("tempPackage() creates package in a repository", async () => {
   await using pkg = await tempPackage({
     config: { name: "@scope/name" },
     commits: [
-      { summary: "feat: feature", tags: ["name@1.2.3"] },
-      { summary: "fix: bug" },
+      { subject: "feat: feature", tags: ["name@1.2.3"] },
+      { subject: "fix: bug" },
     ],
   });
   const repo = git({ cwd: pkg.root });
@@ -82,9 +82,9 @@ Deno.test("tempWorkspace() creates workspace in a repository", async () => {
       { name: "@scope/name3" },
     ],
     commits: [
-      { summary: "fix(name1): bug" },
-      { summary: "feat(name2): feature" },
-      { summary: "feat(name3)!: breaking" },
+      { subject: "fix(name1): bug" },
+      { subject: "feat(name2): feature" },
+      { subject: "feat(name3)!: breaking" },
     ],
   });
   const [pkg1, pkg2, pkg3] = packages;

--- a/tool/forge/testing.ts
+++ b/tool/forge/testing.ts
@@ -38,7 +38,7 @@ export interface TempPackageOptions {
   /** Options for the initialization of the git repository. */
   repo?: TempRepositoryOptions;
   /** Commits and tags to create in the repository. */
-  commits?: { summary: string; tags?: string[] }[];
+  commits?: { subject: string; tags?: string[] }[];
 }
 
 /** Options for the {@linkcode tempWorkspace} function. */
@@ -54,7 +54,7 @@ export interface TempWorkspaceOptions {
   /** Options for the initialization of the git repository. */
   repo?: TempRepositoryOptions;
   /** Commits and tags to create in the repository. */
-  commits?: { summary: string; tags?: string[] }[];
+  commits?: { subject: string; tags?: string[] }[];
 }
 
 /**
@@ -86,7 +86,7 @@ export interface TempWorkspaceOptions {
  * await using pkg = await tempPackage({
  *   config: { name: "@scope/name" },
  *   commits: [
- *     { summary: "release", tags: ["name@1.2.3"] },
+ *     { subject: "release", tags: ["name@1.2.3"] },
  *   ],
  * });
  *
@@ -142,8 +142,8 @@ export async function tempPackage(
  *     { name: "@scope/name2" },
  *   ],
  *   commits: [
- *     { summary: "fix(name1): bug", tags: ["name1@1.2.3"] },
- *     { summary: "fix(name2): bug", tags: ["name2@3.2.1"] },
+ *     { subject: "fix(name1): bug", tags: ["name1@1.2.3"] },
+ *     { subject: "fix(name2): bug", tags: ["name2@3.2.1"] },
  *   ],
  * });
  * const [pkg1, pkg2] = workspace;
@@ -216,9 +216,9 @@ async function createRepository(
   options: TempPackageOptions | TempWorkspaceOptions | undefined,
 ) {
   const repo = await tempRepository(options?.repo);
-  for (const { summary, tags } of options?.commits ?? []) {
+  for (const { subject, tags } of options?.commits ?? []) {
     // deno-lint-ignore no-await-in-loop
-    await repo.commit.create(summary, { allowEmpty: true });
+    await repo.commit.create(subject, { allowEmpty: true });
     for (const tag of tags ?? []) {
       // deno-lint-ignore no-await-in-loop
       await repo.tag.create(tag);


### PR DESCRIPTION
The standard term is subject. Changing for consistency with tag subject.