### PR TITLE
docs: rename Specify agent to Design agent

### DIFF
--- a/.github/agents/design.agent.md
+++ b/.github/agents/design.agent.md
@@ -1,5 +1,5 @@
 ---
-name: Specify
+name: Design
 description: >
   Designs APIs, frameworks, and features. Use proactively when designing
   systems or planning feature architecture.
@@ -10,7 +10,7 @@ handoffs:
     send: false
 ---
 
-# Specify Agent
+# Design Agent
 
 ## Your role
 

--- a/.github/agents/route.agent.md
+++ b/.github/agents/route.agent.md
@@ -27,8 +27,8 @@ You will NOT:
 
 ### Available agents
 
-- [**Specify**](./specify.agent.md): When still deciding on what to build or
-  what the API should look like.
+- [**Design**](./design.agent.md): When creating new APIs, frameworks, or
+  feature architectures.
 - [**Build**](./build.agent.md): When implementing from an existing
   specification or description.
 - [**Fix**](./fix.agent.md): When existing code misbehaves, errors, or needs
@@ -55,9 +55,9 @@ You will NOT:
 
 ### Examples
 
-- User asks to design a new public interface → **Specify**
-- User asks to come up with a new architecture → **Specify**
-- User asks to write a design doc → **Specify**
+- User asks to design a new public interface → **Design**
+- User asks to come up with a new architecture → **Design**
+- User asks to write a design doc → **Design**
 - User asks to implement a new feature from a spec → **Build**
 - User asks to write a simple function → **Build**
 - User asks to add tests for existing code → **Build**


### PR DESCRIPTION
I was striving for distinction with "UI design", but simpler is better.
