### PR TITLE
test(git): more tests for `git().index.restore()`

### DIFF
--- a/core/git/git.test.ts
+++ b/core/git/git.test.ts
@@ -1638,7 +1638,7 @@ Deno.test("git().index.restore({ target }) can restore the index", async () => {
     { path: "file2", status: "modified" },
   ]);
   await repo.index.restore(["file1", "file2"], {
-    target: "index",
+    location: "index",
   });
   assertEquals(await repo.diff.status({ staged: true }), []);
   assertEquals(await repo.diff.status({ staged: false }), [
@@ -1665,7 +1665,7 @@ Deno.test("git().index.restore({ target }) can restore the working tree", async 
     { path: "file2", status: "modified" },
   ]);
   await repo.index.restore(["file1", "file2"], {
-    target: "worktree",
+    location: "worktree",
   });
   assertEquals(await repo.diff.status({ staged: true }), [
     { path: "file1", status: "modified" },
@@ -1691,7 +1691,7 @@ Deno.test("git().index.restore({ target }) can restore the index and working tre
     { path: "file2", status: "modified" },
   ]);
   await repo.index.restore(["file1", "file2"], {
-    target: "both",
+    location: "both",
   });
   assertEquals(await repo.diff.status(), []);
   assertEquals(await Deno.readTextFile(repo.path("file1")), "content1");
@@ -1706,7 +1706,7 @@ Deno.test("git().index.restore({ target }) can revert new files from the index",
   assertEquals(await repo.diff.status({ staged: true }), [
     { path: "file", status: "added" },
   ]);
-  await repo.index.restore("file", { target: "index" });
+  await repo.index.restore("file", { location: "index" });
   assertEquals(await repo.diff.status({ untracked: true }), [
     { path: "file", status: "untracked" },
   ]);

--- a/core/git/git.ts
+++ b/core/git/git.ts
@@ -923,18 +923,22 @@ export interface IndexRestoreOptions {
    * Source commit to restore from.
    *
    * The default restore source depends on the
-   * {@linkcode IndexRestoreOptions.staged staged} option.
+   * {@linkcode IndexRestoreOptions.location location} option.
    *
    * - `HEAD` is the default source, if restoring the index (staging area)
    * - the index is the default source, if restoring the working tree only
    */
   source?: Commitish;
   /**
-   * Target location to restore files in.
+   * Restore location.
+   *
+   * - `index`: restore files in the staging area from source
+   * - `worktree`: restore files in the working tree from source (default)
+   * - `both`: restore both the index and working tree
    *
    * @default {"worktree"}
    */
-  target?: "index" | "worktree" | "both";
+  location?: "index" | "worktree" | "both";
 }
 
 /** Options for the {@linkcode IndexOperations.remove} function. */
@@ -1951,11 +1955,11 @@ export function git(options?: GitOptions): Git {
           flag("--source", commitArg(options?.source), { equals: true }),
           flag(
             "--staged",
-            options?.target === "index" || options?.target === "both",
+            options?.location === "index" || options?.location === "both",
           ),
           flag(
             "--worktree",
-            options?.target === "worktree" || options?.target === "both",
+            options?.location === "worktree" || options?.location === "both",
           ),
           "--",
           path,


### PR DESCRIPTION
This used the wrong branch for a refactor, that is not merged with #518.