### PR TITLE
fix(testing/mock): determine mock mode once

### DIFF
--- a/core/testing/deno.json
+++ b/core/testing/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@roka/testing",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "exports": {
     ".": "./testing.ts",
     "./fake": "./fake.ts",

--- a/core/testing/mock.test.ts
+++ b/core/testing/mock.test.ts
@@ -1,6 +1,5 @@
 import { tempDirectory } from "@roka/fs/temp";
 import { maybe } from "@roka/maybe";
-import { fakeArgs } from "@roka/testing/fake";
 import {
   assertEquals,
   assertFalse,
@@ -10,6 +9,7 @@ import {
 import { dirname, fromFileUrl, join } from "@std/path";
 import { MockError } from "@std/testing/mock";
 import { assertType, type IsExact } from "@std/testing/types";
+import { fakeArgs } from "./fake.ts";
 import { type Mock, mock } from "./mock.ts";
 
 assertType<

--- a/core/testing/mock.test.ts
+++ b/core/testing/mock.test.ts
@@ -1,4 +1,6 @@
+import { tempDirectory } from "@roka/fs/temp";
 import { maybe } from "@roka/maybe";
+import { fakeArgs } from "@roka/testing/fake";
 import {
   assertEquals,
   assertFalse,
@@ -68,6 +70,20 @@ Deno.test("mock() implements spy like interface", async (t) => {
   mocked.restore();
   assertEquals(mocked.restored, true);
   await assertRejects(() => mocked(2, 4), MockError);
+});
+
+Deno.test("mock() determines mode once", async (t) => {
+  await using directory = await tempDirectory();
+  const self = { func: async () => await Promise.resolve(42) };
+  let mocked: ReturnType<typeof mock<typeof self, "func">> | null;
+  {
+    using _ = fakeArgs(["--update"]);
+    mocked = mock(t, self, "func", { path: directory.path("args.mock") });
+  }
+  {
+    using _ = fakeArgs([]);
+    assertEquals(await mocked(), 42);
+  }
 });
 
 Deno.test("mock() matches arguments", async (t) => {

--- a/core/testing/mock.test.ts
+++ b/core/testing/mock.test.ts
@@ -75,7 +75,7 @@ Deno.test("mock() implements spy like interface", async (t) => {
 Deno.test("mock() determines mode once", async (t) => {
   await using directory = await tempDirectory();
   const self = { func: async () => await Promise.resolve(42) };
-  let mocked: ReturnType<typeof mock<typeof self, "func">> | null;
+  let mocked: ReturnType<typeof mock<typeof self, "func">>;
   {
     using _ = fakeArgs(["--update"]);
     mocked = mock(t, self, "func", { path: directory.path("args.mock") });

--- a/core/testing/mock.ts
+++ b/core/testing/mock.ts
@@ -309,6 +309,7 @@ export function mock<
   let state: MockState<Input, Output> | undefined;
   let errored = false;
   const mockContext = MockContext.get();
+  const mode = mockMode(options);
   const conversion = {
     input: {
       convert: options?.conversion?.input?.convert ??
@@ -326,9 +327,9 @@ export function mock<
   ) {
     try {
       if (stubbed.restored) throw new MockError("Mock already restored");
-      state = await mockContext.load(context, self, property, options);
+      state = await mockContext.load(context, self, property, mode, options);
       let output: Output;
-      if (mode(options) === "replay") {
+      if (mode === "replay") {
         const input = await conversion.input.convert(...args);
         output = mockContext.replay(state, property, input);
       } else {
@@ -356,14 +357,14 @@ export function mock<
   const mock = Object.assign(
     fake as Self[Prop],
     {
-      mode: mode(options),
+      mode,
       original: stubbed.original as unknown as Self[Prop],
       restored: false,
       restore() {
         stubbed.restore();
         if (errored) return;
         if (!state) throw new MockError("No calls made");
-        if (mode(state?.options) === "update") return;
+        if (mode === "update") return;
         if (state.remaining.length > 0) {
           throw new MockError(
             `Unmatched calls: ${
@@ -385,7 +386,7 @@ export function mock<
   });
 }
 
-function mode(options: MockOptions | undefined): MockMode {
+function mockMode(options: MockOptions | undefined): MockMode {
   return options?.mode ??
     (Deno.args.some((arg) => arg === "--update" || arg === "-u")
       ? "update"
@@ -407,11 +408,8 @@ function mockPath(
   }
 }
 
-async function checkPermission(
-  path: string,
-  options: MockOptions | undefined,
-) {
-  if (mode(options) !== "update") return;
+async function checkPermission(path: string, mode: MockMode) {
+  if (mode !== "update") return;
   const permission = await Deno.permissions.query({ name: "write", path });
   if (permission.state !== "granted") {
     throw new Deno.errors.PermissionDenied(
@@ -482,9 +480,10 @@ class MockContext {
     context: Deno.TestContext,
     self: Self,
     property: Prop,
+    mode: MockMode,
     options: MockOptions | undefined,
   ): Promise<MockState<Input, Output>> {
-    await checkPermission(mockPath(context, options), options);
+    await checkPermission(mockPath(context, options), mode);
     const path = mockPath(context, options);
     if (!this.mocks.has(path)) {
       const { value: mock, error } = await maybe<
@@ -492,7 +491,7 @@ class MockContext {
       >(() => import(toFileUrl(path).toString()));
       if (error) {
         if (!(error instanceof TypeError)) throw error;
-        if (mode(options) === "replay") {
+        if (mock === "replay") {
           throw new MockError(`No mock found: ${path}`);
         }
       }
@@ -587,7 +586,7 @@ class MockContext {
     const removedNames: string[] = [];
     for (const [path, { records, states }] of this.mocks.entries()) {
       const updatedStates = Array.from(
-        states.values().filter((state) => mode(state.options) === "update"),
+        states.values().filter((state) => mockMode(state.options) === "update"),
       );
       if (!updatedStates.length) continue;
       const contents = [`export const mock = {};\n`];

--- a/core/testing/mock.ts
+++ b/core/testing/mock.ts
@@ -309,7 +309,10 @@ export function mock<
   let state: MockState<Input, Output> | undefined;
   let errored = false;
   const mockContext = MockContext.get();
-  const mode = mockMode(options);
+  const mode = options?.mode ??
+    (Deno.args.some((arg) => arg === "--update" || arg === "-u")
+      ? "update"
+      : "replay");
   const conversion = {
     input: {
       convert: options?.conversion?.input?.convert ??
@@ -386,13 +389,6 @@ export function mock<
   });
 }
 
-function mockMode(options: MockOptions | undefined): MockMode {
-  return options?.mode ??
-    (Deno.args.some((arg) => arg === "--update" || arg === "-u")
-      ? "update"
-      : "replay");
-}
-
 function mockPath(
   context: Deno.TestContext,
   options: MockOptions | undefined,
@@ -445,6 +441,7 @@ interface MockCall<Input, Output> {
 
 interface MockState<Input, Output> {
   name: string;
+  mode: MockMode;
   path: string;
   options: MockOptions | undefined;
   calls: MockCall<Input, Output>[];
@@ -491,9 +488,7 @@ class MockContext {
       >(() => import(toFileUrl(path).toString()));
       if (error) {
         if (!(error instanceof TypeError)) throw error;
-        if (mock === "replay") {
-          throw new MockError(`No mock found: ${path}`);
-        }
+        if (mode === "replay") throw new MockError(`No mock found: ${path}`);
       }
       if (!this.mocks.has(path)) {
         this.mocks.set(path, {
@@ -519,6 +514,7 @@ class MockContext {
       ];
       mock.states.set(name, {
         name,
+        mode,
         path,
         options,
         calls: [],
@@ -586,7 +582,7 @@ class MockContext {
     const removedNames: string[] = [];
     for (const [path, { records, states }] of this.mocks.entries()) {
       const updatedStates = Array.from(
-        states.values().filter((state) => mockMode(state.options) === "update"),
+        states.values().filter((state) => state.mode === "update"),
       );
       if (!updatedStates.length) continue;
       const contents = [`export const mock = {};\n`];


### PR DESCRIPTION
Mock had a buggy interaction with `fakeArgs` where the the mock was
using the mock mode from the arguments altered after mock creation.
